### PR TITLE
Parallelize with rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "derive_deref"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +215,12 @@ dependencies = [
  "lazy_static",
  "tempfile",
 ]
+
+[[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "encode_unicode"
@@ -233,6 +286,7 @@ dependencies = [
  "glob",
  "log",
  "paw",
+ "rayon",
  "structopt",
  "tempfile",
  "textwrap",
@@ -375,10 +429,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
+
+[[package]]
+name = "memoffset"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "num-integer"
@@ -397,6 +466,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -573,6 +652,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+dependencies = [
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +733,27 @@ dependencies = [
  "quote 1.0.2",
  "syn 1.0.14",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ paw = "1.0"
 structopt = { version = "0.3", features = [ "paw" ] }
 anyhow = "1.0.26"
 glob = "0.3.0"
+rayon = "1.3.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,13 @@ mod subprocess;
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
+use std::ops::Deref;
 
 use anyhow::{Context, Result};
 use git2::{BranchType, Config as GitConfig, Direction, Error as GitError, ErrorCode, Repository};
 use glob::Pattern;
 use log::*;
+use rayon::prelude::*;
 
 use crate::args::{Category, DeleteFilter};
 use crate::remote_ref::{get_fetch_remote_ref, get_push_remote_ref};
@@ -307,9 +309,16 @@ pub fn get_merged_or_gone(git: &Git, config: &Config) -> Result<MergedOrGone> {
     }
 
     let classifications = base_and_branch_to_compare
-        .into_iter()
-        .map(|(base_remote_ref, branch_name)| {
-            classify(git, &merged_locals, &base_remote_ref, &branch_name)
+        .into_par_iter()
+        .map({
+            // git's fields are semantically Send + Sync in the `classify`.
+            // They are read only in `classify` function.
+            // It is denoted that it is safe in that case
+            // https://github.com/libgit2/libgit2/blob/master/docs/threading.md#sharing-objects
+            let git = ForceSendSync(git);
+            move |(base_remote_ref, branch_name)| {
+                classify(git, &merged_locals, &base_remote_ref, &branch_name)
+            }
         })
         .collect::<Result<Vec<_>, _>>()?;
 
@@ -341,8 +350,9 @@ struct Classification {
     result: MergedOrGone,
 }
 
+/// Make sure repo and config are semantically Send + Sync.
 fn classify(
-    git: &Git,
+    git: ForceSendSync<&Git>,
     merged_locals: &HashSet<String>,
     base_remote_ref: &str,
     branch_name: &str,
@@ -402,6 +412,23 @@ fn classify(
     }
 
     Ok(c)
+}
+
+/// Use with caution.
+/// It makes wrapping type T to be Send + Sync.
+/// Make sure T is semantically Send + Sync
+#[derive(Copy, Clone)]
+struct ForceSendSync<T>(T);
+
+unsafe impl<T> Sync for ForceSendSync<T> {}
+unsafe impl<T> Send for ForceSendSync<T> {}
+
+impl<T> Deref for ForceSendSync<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 /// if there are following references:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod simple_glob;
 mod subprocess;
 
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 
 use anyhow::{Context, Result};
 use git2::{BranchType, Config as GitConfig, Direction, Error as GitError, ErrorCode, Repository};
@@ -15,7 +16,6 @@ use crate::args::{Category, DeleteFilter};
 use crate::remote_ref::{get_fetch_remote_ref, get_push_remote_ref};
 use crate::simple_glob::{expand_refspec, ExpansionSide};
 pub use crate::subprocess::remote_update;
-use std::convert::TryFrom;
 
 pub struct Git {
     pub repo: Repository,
@@ -194,6 +194,16 @@ impl MergedOrGone {
         }
         result
     }
+
+    pub fn accumulate(mut self, mut other: Self) -> Self {
+        self.merged_locals.extend(other.merged_locals.drain());
+        self.gone_locals.extend(other.gone_locals.drain());
+        self.kept_back.extend(other.kept_back.drain());
+        self.merged_remotes.extend(other.merged_remotes.drain());
+        self.gone_remotes.extend(other.gone_remotes.drain());
+
+        self
+    }
 }
 
 fn keep_branches(
@@ -258,6 +268,7 @@ pub fn get_merged_or_gone(git: &Git, config: &Config) -> Result<MergedOrGone> {
     let mut merged_locals = HashSet::new();
     merged_locals.extend(noff_merged_locals);
 
+    let mut base_and_branch_to_compare = Vec::new();
     for branch in git.repo.branches(Some(BranchType::Local))? {
         let (branch, _) = branch?;
         let branch_name = branch.name()?.context("non-utf8 branch name")?;
@@ -290,52 +301,25 @@ pub fn get_merged_or_gone(git: &Git, config: &Config) -> Result<MergedOrGone> {
             debug!("Skip: the branch is a symbolic ref: {:?}", branch_name);
             continue;
         }
-        let merged = merged_locals.contains(branch_name)
-            || subprocess::is_merged(&git.repo, &base_remote_refs, branch_name)?;
-        let fetch = get_fetch_remote_ref(&git.repo, &git.config, branch_name)?;
-        let push = get_push_remote_ref(&git.repo, &git.config, branch_name)?;
-        trace!("merged: {}", merged);
-        trace!("fetch: {:?}", fetch);
-        trace!("push: {:?}", push);
-        match (fetch, push) {
-            (Some(_), Some(remote_ref)) if merged => {
-                debug!("merged local, merged remote: the branch is merged, but forgot to delete");
-                result.merged_locals.insert(branch_name.to_string());
-                result.merged_remotes.insert(remote_ref);
-            }
-            (Some(_), Some(_)) => {
-                debug!("skip: live branch. not merged, not gone");
-            }
-
-            // `git branch`'s shows `%(upstream)` as s `%(push)` fallback if there isn't a specified push remote.
-            // But our `get_push_remote_ref` doesn't.
-            (Some(fetch_ref), None) if merged => {
-                debug!("merged local, merged remote: the branch is merged, but forgot to delete");
-                result.merged_locals.insert(branch_name.to_string());
-                result.merged_remotes.insert(fetch_ref);
-            }
-            (Some(_), None) => {
-                debug!("skip: it might be a long running branch like 'develop' in a git-flow");
-            }
-
-            (None, Some(remote_ref)) if merged => {
-                debug!("merged remote: it might be a long running branch like 'develop' which is once pushed to the personal git.repo in the triangular workflow, but the branch is merged on the upstream");
-                result.merged_remotes.insert(remote_ref);
-            }
-            (None, Some(remote_ref)) => {
-                debug!("gone remote: it might be a long running branch like 'develop' which is once pushed to the personal git.repo in the triangular workflow, but the branch is gone on the upstream");
-                result.gone_remotes.insert(remote_ref);
-            }
-
-            (None, None) if merged => {
-                debug!("merged local: the branch is merged, and deleted");
-                result.merged_locals.insert(branch_name.to_string());
-            }
-            (None, None) => {
-                debug!("gone local: the branch is not merged but gone somehow");
-                result.gone_locals.insert(branch_name.to_string());
-            }
+        for base_remote_ref in &base_remote_refs {
+            base_and_branch_to_compare.push((base_remote_ref.to_string(), branch_name.to_string()));
         }
+    }
+
+    let classifications = base_and_branch_to_compare
+        .into_iter()
+        .map(|(base_remote_ref, branch_name)| {
+            classify(git, &merged_locals, &base_remote_ref, &branch_name)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for classification in classifications.into_iter() {
+        debug!("branch: {}", classification.branch_name);
+        trace!("merged: {}", classification.branch_is_merged);
+        trace!("push: {:?}", classification.fetch);
+        trace!("fetch: {:?}", classification.push);
+        debug!("message: {}", classification.message);
+        result = result.accumulate(classification.result);
     }
 
     result.keep_base(&git.repo, &git.config, &config.bases)?;
@@ -346,6 +330,78 @@ pub fn get_merged_or_gone(git: &Git, config: &Config) -> Result<MergedOrGone> {
     }
 
     Ok(result)
+}
+
+struct Classification {
+    branch_name: String,
+    branch_is_merged: bool,
+    fetch: Option<String>,
+    push: Option<String>,
+    message: &'static str,
+    result: MergedOrGone,
+}
+
+fn classify(
+    git: &Git,
+    merged_locals: &HashSet<String>,
+    base_remote_ref: &str,
+    branch_name: &str,
+) -> Result<Classification> {
+    let merged = merged_locals.contains(branch_name)
+        || subprocess::is_merged(&git.repo, base_remote_ref, branch_name)?;
+    let fetch = get_fetch_remote_ref(&git.repo, &git.config, branch_name)?;
+    let push = get_push_remote_ref(&git.repo, &git.config, branch_name)?;
+
+    let mut c = Classification {
+        branch_name: branch_name.to_string(),
+        branch_is_merged: merged,
+        fetch: fetch.clone(),
+        push: push.clone(),
+        message: "",
+        result: MergedOrGone::default(),
+    };
+
+    match (fetch, push) {
+        (Some(_), Some(remote_ref)) if merged => {
+            c.message = "merged local, merged remote: the branch is merged, but forgot to delete";
+            c.result.merged_locals.insert(branch_name.to_string());
+            c.result.merged_remotes.insert(remote_ref);
+        }
+        (Some(_), Some(_)) => {
+            c.message = "skip: live branch. not merged, not gone";
+        }
+
+        // `git branch`'s shows `%(upstream)` as s `%(push)` fallback if there isn't a specified push remote.
+        // But our `get_push_remote_ref` doesn't.
+        (Some(fetch_ref), None) if merged => {
+            c.message = "merged local, merged remote: the branch is merged, but forgot to delete";
+            c.result.merged_locals.insert(branch_name.to_string());
+            c.result.merged_remotes.insert(fetch_ref);
+        }
+        (Some(_), None) => {
+            c.message = "skip: it might be a long running branch like 'develop' in a git-flow";
+        }
+
+        (None, Some(remote_ref)) if merged => {
+            c.message = "merged remote: it might be a long running branch like 'develop' which is once pushed to the personal git.repo in the triangular workflow, but the branch is merged on the upstream";
+            c.result.merged_remotes.insert(remote_ref);
+        }
+        (None, Some(remote_ref)) => {
+            c.message = "gone remote: it might be a long running branch like 'develop' which is once pushed to the personal git.repo in the triangular workflow, but the branch is gone on the upstream";
+            c.result.gone_remotes.insert(remote_ref);
+        }
+
+        (None, None) if merged => {
+            c.message = "merged local: the branch is merged, and deleted";
+            c.result.merged_locals.insert(branch_name.to_string());
+        }
+        (None, None) => {
+            c.message = "gone local: the branch is not merged but gone somehow";
+            c.result.gone_locals.insert(branch_name.to_string());
+        }
+    }
+
+    Ok(c)
 }
 
 /// if there are following references:

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
@@ -6,7 +7,6 @@ use log::*;
 
 use crate::config::get_remote;
 use crate::remote_ref::get_fetch_remote_ref;
-use std::collections::HashSet;
 
 fn git(repo: &Repository, args: &[&str]) -> Result<()> {
     let workdir = repo.workdir().context("Bare repository is not supported")?;
@@ -55,16 +55,10 @@ pub fn remote_update(repo: &Repository, dry_run: bool) -> Result<()> {
     }
 }
 
-pub fn is_merged(repo: &Repository, base_remote_refs: &[String], branch: &str) -> Result<bool> {
-    for base_remote_ref in base_remote_refs {
-        let merge_base = git_output(&repo, &["merge-base", base_remote_ref, branch])?;
-        if is_merged_by_rev_list(repo, base_remote_ref, branch)?
-            || is_squash_merged(repo, &merge_base, base_remote_ref, branch)?
-        {
-            return Ok(true);
-        }
-    }
-    Ok(false)
+pub fn is_merged(repo: &Repository, base_remote_ref: &str, branch: &str) -> Result<bool> {
+    let merge_base = git_output(&repo, &["merge-base", base_remote_ref, branch])?;
+    Ok(is_merged_by_rev_list(repo, base_remote_ref, branch)?
+        || is_squash_merged(repo, &merge_base, base_remote_ref, branch)?)
 }
 
 fn is_merged_by_rev_list(repo: &Repository, base: &str, branch: &str) -> Result<bool> {


### PR DESCRIPTION
I've coerced `&Repository` and `&Config` to be `Send + Sync`.
They are just reading states from the git, so I believe they are "semantically" safe to share between threads.
https://github.com/libgit2/libgit2/blob/master/docs/threading.md#sharing-objects

On my machine, it really does reduces the overall time (i7-4702MQ, 4 cores)
With 16 branches that is generated with this script https://github.com/foriequal0/git-trim/issues/22#issuecomment-587084485
before:
```
git trim --dry-run --no-update  18.94s user 0.90s system 99% cpu 19.957 total
```
after:
```
git trim --dry-run --no-update  19.18s user 0.99s system 257% cpu 7.823 total
```

I think this might be premature optimization though. It hurts the readability of logs. But it is fun to do it. 