### PR TITLE
Show real failed branch name in panic message

### DIFF
--- a/src/remote_ref.rs
+++ b/src/remote_ref.rs
@@ -123,7 +123,7 @@ fn get_push_ref_on_remote(
             {
                 Ok(Some(merge.clone()))
             } else {
-                panic!("The current branch foo has no upstream branch.");
+                panic!("The current branch {} has no upstream branch.", branch);
             }
         }
         "nothing" | "matching" => {


### PR DESCRIPTION
Thanks for this project, it looks very interesting. I was just trying it out on one of my git repos and got this error message:

```
Fetching origin

thread 'main' panicked at 'The current branch foo has no upstream branch.', src/remote_ref.rs:126:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```
(the backtrace is almost entirely `<unknown>` so I won't bother posting it)

I went looking for a local or remote branch named `foo` and couldn't find one, so I looked at the line referenced in the error and saw that `foo` was hardcoded into the error message. I built the project locally and this fixes the error message for me, now I get:

```
Fetching origin

thread 'main' panicked at 'The current branch master has no upstream branch.', src/remote_ref.rs:126:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

I still haven't dug in to see what my repository's actual problem is, but this will help me debug.