### PR TITLE
Filter remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,18 @@ You can override it with CLI option with `--protected release-*`
 
 ### `git config trim.delete`
 
-Comma separated values of `all`, `merged`, `gone`, `local`, `remote`, `merged-local`, `merged-remote`, `gone-local`, `gone-remote`.
-`all` is equivalent to `merged-local,merged-remote,gone-local,gone-remote`.
-`merged` is equivalent to `merged-local,merged-remote`.
-`gone` is equivalent to `gone-local,gone-remote`.
-`local` is equivalent to `merged-local,gone-local`.
-`remote` is equivalent to `merged-remote,gone-remote`.
+Comma separated values of `<filter unit>[:<remote name>]`.
+Filter unit is one of the `all`, `merged`, `gone`, `local`, `remote`, `merged-local`, `merged-remote`, `gone-local`, `gone-remote`.
+`all` implies `merged-local,merged-remote,gone-local,gone-remote`.
+`merged` implies `merged-local,merged-remote`.
+`gone` implies `gone-local,gone-remote`.
+`local` implies `merged-local,gone-local`.
+`remote` implies `merged-remote,gone-remote`.
+
+You can scope a filter unit to specific remote `:<remote name>` to a `filter unit`
+if the filter unit implies `merged-remote` or `gone-remote`.
+If there are filter units that is scoped, it trims merged or gone remote branches in the specified remote branch.
+If there are any filter unit that isn't scoped, it trims all merged or gone remote branches.
 
 The default value is `merged`.
 

--- a/tests/filter_accidential_track.rs
+++ b/tests/filter_accidential_track.rs
@@ -1,0 +1,130 @@
+mod fixture;
+
+use std::convert::TryFrom;
+
+use anyhow::Result;
+use git2::Repository;
+
+use git_trim::args::{DeleteFilter, FilterUnit, Scope};
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone};
+
+use fixture::{rc, Fixture};
+use std::iter::FromIterator;
+
+fn fixture() -> Fixture {
+    rc().append_fixture_trace(
+        r#"
+        git init origin --bare
+
+        git clone origin local
+        local <<EOF
+            git config user.name "Local Test"
+            git config user.email "local@test"
+            git config remote.pushdefault origin
+            git config push.default simple
+
+            echo "Hello World!" > README.md
+            git add README.md
+            git commit -m "Initial commit"
+            git push -u origin master
+        EOF
+
+        git clone origin contributer
+        within contributer <<EOF
+            git config user.name "Contributer Test"
+            git config user.email "contributer@test"
+            git config remote.pushdefault origin
+            git config push.default simple
+        EOF
+
+        within contributer <<EOF
+            git checkout -b feature
+            touch awesome-patch
+            git add awesome-patch
+            git commit -m "Awesome patch"
+            touch another-patch
+            git add another-patch
+            git commit -m "Another patch"
+            git push -u origin feature
+        EOF
+
+        local <<EOF
+            git remote add contributer ../contributer
+            git remote update
+        EOF
+        "#,
+    )
+}
+
+fn config() -> Config<'static> {
+    Config {
+        bases: vec!["master"],
+        protected_branches: set! {},
+        filter: DeleteFilter::from_iter(vec![
+            FilterUnit::MergedLocal,
+            FilterUnit::MergedRemote(Scope::Scoped("origin".to_string())),
+        ]),
+        detach: true,
+    }
+}
+
+#[test]
+fn test_default_config_tries_to_delete_accidential_track() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        local <<EOF
+            git checkout --track contributer/feature
+
+            git checkout master
+            git merge feature --no-ff
+            git push -u origin master
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let branches = get_merged_or_gone(
+        &git,
+        &Config {
+            filter: DeleteFilter::all(),
+            ..config()
+        },
+    )?;
+    assert_eq!(
+        branches.to_delete,
+        MergedOrGone {
+            merged_locals: set! {"feature"},
+            merged_remotes: set! {"refs/remotes/contributer/feature"},
+            ..Default::default()
+        },
+    );
+    Ok(())
+}
+
+#[test]
+fn test_accidential_track() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        local <<EOF
+            git checkout --track contributer/feature
+
+            git checkout master
+            git merge feature --no-ff
+            git push -u origin master
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let branches = get_merged_or_gone(&git, &config())?;
+    assert_eq!(
+        branches.to_delete,
+        MergedOrGone {
+            merged_locals: set! {"feature"},
+            ..Default::default()
+        },
+    );
+    Ok(())
+}


### PR DESCRIPTION
You can scope remotes to trim with `--delete merged:origin` or `git config trim.delete merged:origin`

Resolves: https://github.com/foriequal0/git-trim/issues/41