### PR TITLE
Can set multiple git config entries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,12 @@ fn main(args: Args) -> Result<()> {
             String::from("develop"),
             String::from("master"),
         ]))
-        .parse()?
+        .parse_flatten()?
         .expect("has default");
     let protected = config::get(&git.config, "trim.protected")
         .with_explicit("cli", flatten_collect(args.protected.clone()).into_option())
         .with_default(&CommaSeparatedSet::from_iter(bases.iter().cloned()))
-        .parse()?
+        .parse_flatten()?
         .expect("has default");
     let update = config::get(&git.config, "trim.update")
         .with_explicit("cli", args.update())
@@ -53,7 +53,7 @@ fn main(args: Args) -> Result<()> {
     let filter = config::get(&git.config, "trim.delete")
         .with_explicit("cli", flatten_collect(args.delete.clone()).into_option())
         .with_default(&DeleteFilter::merged())
-        .parse()?
+        .parse_flatten()?
         .expect("has default");
 
     info!("bases: {:?}", bases);


### PR DESCRIPTION
Now it can accept multiple git config entries similar to the CLI which
can accept multiple args like `--delete remotes:origin --delete remotes:upstream` not only comma-separated lists
See the example:
```
[trim]
	delete=merged-local,gone-remotes
	delete=merged-remotes:origin
	delete=merged-remotes:upstream
```