### PR TITLE
Fix an interpretation of empty mutli-entry configs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -150,11 +150,11 @@ where
         }
 
         let result = match Vec::<String>::get_config_value(self.config, self.key) {
-            Ok(values) => Some(ConfigValue::Explicit {
+            Ok(values) if !values.is_empty() => Some(ConfigValue::Explicit {
                 value: parse(&values)?,
                 source: self.key.to_string(),
             }),
-            Err(err) if config_not_exist(&err) => {
+            Ok(_) => {
                 if let Some(default) = self.default {
                     Some(ConfigValue::Implicit(default.clone()))
                 } else {


### PR DESCRIPTION
There was a bug that git-trim interprets a config as an explicit empty
when a user didn't put any entry, which an implicit defualt should
be applied

The bug is introduced in this PR:
https://github.com/foriequal0/git-trim/pull/45