### PR TITLE
Add a man file

### DIFF
--- a/docs/git-trim.md
+++ b/docs/git-trim.md
@@ -1,0 +1,64 @@
+# git-trim(1) -- Trim git remote tracking branches
+
+## SYNOPSIS
+
+`git-trim`
+
+`git-trim --delete all --dry-run`
+
+## DESCRIPTION
+
+`git-trim` automatically trims your git remote tracking branches that are merged or gone.
+
+## FLAGS
+
+--dry-run
+
+Do not delete branches, show what branches will be deleted.
+
+-h, --help
+
+Prints help information.
+
+--no-confirm
+
+Do not ask confirm. [config: trim.confirm]
+
+--no-detach
+
+Do not detach when HEAD is about to be deleted. [config: trim.detach]
+
+--no-update
+
+Not update remotes. [config: trim.update]
+
+-V, --version
+
+Prints version information
+
+## OPTIONS
+
+-b, --bases &lt;bases&gt;...
+
+Comma separated or multiple arguments of refs that other refs are compared to determine whether it is merged or gone.
+[default: master][config: trim.base]
+
+-d, --delete &lt;delete&gt;
+
+Comma separated values of '&lt;filter unit&gt;[:&lt;remote name&gt;]'. Filter unit is one of the 'all, merged, gone,
+local, remote, merged-local, merged-remote, gone-local, gone-remote'.
+
+- 'all' implies 'merged-local,merged-remote,gone-local,gone-remote'.
+- 'merged' implies 'merged-local,merged-remote'.
+- 'gone' implies 'gone-local,gone-remote'.
+- 'local' implies 'merged-local,gone-local'.
+- 'remote' implies 'merged-remote,gone-remote'.
+
+You can scope a filter unit to specific remote ':&lt;remote name&gt;' to a 'filter unit' if the filter unit
+implies 'merged-remote' or 'gone-remote'. If there are filter units that are scoped, it trims merged or gone
+remote branches in the specified remote branch. If there are any filter unit that isn't scoped, it trims all
+merged or gone remote branches. [default : 'merged'] [config: trim.filter]
+
+-p, --protected &lt;protected&gt;...
+
+Comma separated or multiple arguments of glob pattern of branches that never be deleted

--- a/docs/git-trim.md.1
+++ b/docs/git-trim.md.1
@@ -1,0 +1,60 @@
+.\" generated with Ronn-NG/v0.8.0
+.\" http://github.com/apjanke/ronn-ng/tree/0.8.0
+.TH "GIT\-TRIM" "1" "March 2020" "" ""
+.SH "NAME"
+\fBgit\-trim\fR \- Trim git remote tracking branches
+.SH "SYNOPSIS"
+\fBgit\-trim\fR
+.P
+\fBgit\-trim \-\-delete all \-\-dry\-run\fR
+.SH "DESCRIPTION"
+\fBgit\-trim\fR automatically trims your git remote tracking branches that are merged or gone\.
+.SH "FLAGS"
+\-\-dry\-run
+.P
+Do not delete branches, show what branches will be deleted\.
+.P
+\-h, \-\-help
+.P
+Prints help information\.
+.P
+\-\-no\-confirm
+.P
+Do not ask confirm\. [config: trim\.confirm]
+.P
+\-\-no\-detach
+.P
+Do not detach when HEAD is about to be deleted\. [config: trim\.detach]
+.P
+\-\-no\-update
+.P
+Not update remotes\. [config: trim\.update]
+.P
+\-V, \-\-version
+.P
+Prints version information
+.SH "OPTIONS"
+\-b, \-\-bases <bases>\|\.\|\.\|\.
+.P
+Comma separated or multiple arguments of refs that other refs are compared to determine whether it is merged or gone\. [default: master][config: trim\.base]
+.P
+\-d, \-\-delete <delete>
+.P
+Comma separated values of \'<filter unit>[:<remote name>]\'\. Filter unit is one of the \'all, merged, gone, local, remote, merged\-local, merged\-remote, gone\-local, gone\-remote\'\.
+.IP "\[ci]" 4
+\'all\' implies \'merged\-local,merged\-remote,gone\-local,gone\-remote\'\.
+.IP "\[ci]" 4
+\'merged\' implies \'merged\-local,merged\-remote\'\.
+.IP "\[ci]" 4
+\'gone\' implies \'gone\-local,gone\-remote\'\.
+.IP "\[ci]" 4
+\'local\' implies \'merged\-local,gone\-local\'\.
+.IP "\[ci]" 4
+\'remote\' implies \'merged\-remote,gone\-remote\'\.
+.IP "" 0
+.P
+You can scope a filter unit to specific remote \':<remote name>\' to a \'filter unit\' if the filter unit implies \'merged\-remote\' or \'gone\-remote\'\. If there are filter units that are scoped, it trims merged or gone remote branches in the specified remote branch\. If there are any filter unit that isn\'t scoped, it trims all merged or gone remote branches\. [default : \'merged\'] [config: trim\.filter]
+.P
+\-p, \-\-protected <protected>\|\.\|\.\|\.
+.P
+Comma separated or multiple arguments of glob pattern of branches that never be deleted

--- a/docs/git-trim.md.1.html
+++ b/docs/git-trim.md.1.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' content='text/html;charset=utf8'>
+  <meta name='generator' content='Ronn-NG/v0.8.0 (http://github.com/apjanke/ronn-ng/tree/0.8.0)'>
+  <title>git-trim(1) - Trim git remote tracking branches</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#DESCRIPTION">DESCRIPTION</a>
+    <a href="#FLAGS">FLAGS</a>
+    <a href="#OPTIONS">OPTIONS</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>git-trim(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>git-trim(1)</li>
+  </ol>
+
+
+
+<h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>git-trim</code> - <span class="man-whatis">Trim git remote tracking branches</span>
+</p>
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>git-trim</code></p>
+
+<p><code>git-trim --delete all --dry-run</code></p>
+
+<h2 id="DESCRIPTION">DESCRIPTION</h2>
+
+<p><code>git-trim</code> automatically trims your git remote tracking branches that are merged or gone.</p>
+
+<h2 id="FLAGS">FLAGS</h2>
+
+<p>--dry-run</p>
+
+<p>Do not delete branches, show what branches will be deleted.</p>
+
+<p>-h, --help</p>
+
+<p>Prints help information.</p>
+
+<p>--no-confirm</p>
+
+<p>Do not ask confirm. [config: trim.confirm]</p>
+
+<p>--no-detach</p>
+
+<p>Do not detach when HEAD is about to be deleted. [config: trim.detach]</p>
+
+<p>--no-update</p>
+
+<p>Not update remotes. [config: trim.update]</p>
+
+<p>-V, --version</p>
+
+<p>Prints version information</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<p>-b, --bases &lt;bases&gt;...</p>
+
+<p>Comma separated or multiple arguments of refs that other refs are compared to determine whether it is merged or gone.
+[default: master][config: trim.base]</p>
+
+<p>-d, --delete &lt;delete&gt;</p>
+
+<p>Comma separated values of '&lt;filter unit&gt;[:&lt;remote name&gt;]'. Filter unit is one of the 'all, merged, gone,
+local, remote, merged-local, merged-remote, gone-local, gone-remote'.</p>
+
+<ul>
+<li>'all' implies 'merged-local,merged-remote,gone-local,gone-remote'.</li>
+<li>'merged' implies 'merged-local,merged-remote'.</li>
+<li>'gone' implies 'gone-local,gone-remote'.</li>
+<li>'local' implies 'merged-local,gone-local'.</li>
+<li>'remote' implies 'merged-remote,gone-remote'.</li>
+</ul>
+
+
+<p>You can scope a filter unit to specific remote ':&lt;remote name&gt;' to a 'filter unit' if the filter unit
+implies 'merged-remote' or 'gone-remote'. If there are filter units that are scoped, it trims merged or gone
+remote branches in the specified remote branch. If there are any filter unit that isn't scoped, it trims all
+merged or gone remote branches. [default : 'merged'] [config: trim.filter]</p>
+
+<p>-p, --protected &lt;protected&gt;...</p>
+
+<p>Comma separated or multiple arguments of glob pattern of branches that never be deleted</p>
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>March 2020</li>
+    <li class='tr'>git-trim(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/src/args.rs
+++ b/src/args.rs
@@ -287,6 +287,7 @@ pub struct Args {
     #[structopt(short, long)]
     pub delete: Vec<DeleteFilter>,
 
+    /// Do not delete branches, show what branches will be deleted.
     #[structopt(long)]
     pub dry_run: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -245,11 +245,11 @@ impl<T> CommaSeparatedSet<T> {
 
 #[derive(structopt::StructOpt)]
 pub struct Args {
-    /// Comma separated or a multiple arguments of refs that other refs are compared to determine whether it is merged or gone. [default: master] [config: trim.base]
+    /// Comma separated or multiple arguments of refs that other refs are compared to determine whether it is merged or gone. [default: master] [config: trim.base]
     #[structopt(short, long, aliases=&["base"])]
     pub bases: Vec<CommaSeparatedSet<String>>,
 
-    /// Comma separated or a multiple arguments of glob pattern of branches that never be deleted.
+    /// Comma separated or multiple arguments of glob pattern of branches that never be deleted.
     #[structopt(short, long)]
     pub protected: Vec<CommaSeparatedSet<String>>,
 
@@ -281,7 +281,7 @@ pub struct Args {
     ///
     /// You can scope a filter unit to specific remote ':<remote name>' to a 'filter unit'
     /// if the filter unit implies 'merged-remote' or 'gone-remote'.
-    /// If there are filter units that is scoped, it trims merged or gone remote branches in the specified remote branch.
+    /// If there are filter units that are scoped, it trims merged or gone remote branches in the specified remote branch.
     /// If there are any filter unit that isn't scoped, it trims all merged or gone remote branches.
     /// [default : 'merged'] [config: trim.filter]
     #[structopt(short, long)]


### PR DESCRIPTION
I generated the man file using [ronn](https://github.com/rtomayko/ronn).

There are too many methods to generate a man page.
I'll find out some of the methods and suggest one.

I copied the man page from a terminal:
```
GIT-TRIM(1)                                                        GIT-TRIM(1)



NAME
       git-trim - Trim git remote tracking branches

SYNOPSIS
       git-trim

       git-trim --delete all --dry-run

DESCRIPTION
       git-trim automatically trims your git remote tracking branches that are
       merged or gone.

FLAGS
       --dry-run

       Do not delete branches, show what branches will be deleted.

       -h, --help

       Prints help information.

       --no-confirm

       Do not ask confirm. [config: trim.confirm]

       --no-detach

       Do not detach when HEAD is about to be deleted. [config: trim.detach]

       --no-update

       Not update remotes. [config: trim.update]

       -V, --version

       Prints version information

OPTIONS
       -b, --bases <bases>...

       Comma separated or a multiple arguments of refs  that  other  refs  are
       compared  to  determine  whether  it  is merged or gone. [default: mas-
       ter][config: trim.base]

       -d, --delete <delete>

       Comma separated values of '<filter unit>[:<remote name>]'. Filter  unit
       is  one  of  the  'all,  merged,  gone,  local,  remote,  merged-local,
       merged-remote, gone-local, gone-remote'.

       O   'all' implies 'merged-local,merged-remote,gone-local,gone-remote'.

       O   'merged' implies 'merged-local,merged-remote'.

       O   'gone' implies 'gone-local,gone-remote'.

       O   'local' implies 'merged-local,gone-local'.

       O   'remote' implies 'merged-remote,gone-remote'.



       You can scope a filter unit to specific remote ':<remote  name>'  to  a
       'filter  unit'  if the filter unit implies 'merged-remote' or 'gone-re-
       mote'. If there are filter units that is scoped,  it  trims  merged  or
       gone  remote  branches in the specified remote branch. If there are any
       filter unit that isn't scoped, it  trims  all  merged  or  gone  remote
       branches. [default : 'merged'] [config: trim.filter]

       -p, --protected <protected>...

       Comma  separated  or  a  multiple arguments of glob pattern of branches
       that never be deleted



                                  March 2020                       GIT-TRIM(1)

```
