### PR TITLE
Push delete hub-style checked-out branches

### DIFF
--- a/docs/git-trim.md
+++ b/docs/git-trim.md
@@ -56,7 +56,7 @@ local, remote, merged-local, merged-remote, gone-local, gone-remote'.
 
 You can scope a filter unit to specific remote ':&lt;remote name&gt;' to a 'filter unit' if the filter unit
 implies 'merged-remote' or 'gone-remote'. If there are filter units that are scoped, it trims remote branches only in the specified remote.
-If there are any filter unit that isn't scoped, it trims all remote branches. [default : 'merged'] [config: trim.filter]
+If there are any filter unit that isn't scoped, it trims all remote branches. [default : 'merged:origin'] [config: trim.filter]
 
 -p, --protected &lt;protected&gt;...
 

--- a/docs/git-trim.md.1
+++ b/docs/git-trim.md.1
@@ -53,7 +53,7 @@ Comma separated values of \'<filter unit>[:<remote name>]\'\. Filter unit is one
 \'remote\' implies \'merged\-remote,gone\-remote\'\.
 .IP "" 0
 .P
-You can scope a filter unit to specific remote \':<remote name>\' to a \'filter unit\' if the filter unit implies \'merged\-remote\' or \'gone\-remote\'\. If there are filter units that are scoped, it trims merged or gone remote branches in the specified remote branch\. If there are any filter unit that isn\'t scoped, it trims all merged or gone remote branches\. [default : \'merged\'] [config: trim\.filter]
+You can scope a filter unit to specific remote \':<remote name>\' to a \'filter unit\' if the filter unit implies \'merged\-remote\' or \'gone\-remote\'\. If there are filter units that are scoped, it trims merged or gone remote branches in the specified remote branch\. If there are any filter unit that isn\'t scoped, it trims all merged or gone remote branches\. [default : \'merged:origin\'] [config: trim\.filter]
 .P
 \-p, \-\-protected <protected>\|\.\|\.\|\.
 .P

--- a/docs/git-trim.md.1.html
+++ b/docs/git-trim.md.1.html
@@ -132,7 +132,7 @@ local, remote, merged-local, merged-remote, gone-local, gone-remote'.</p>
 <p>You can scope a filter unit to specific remote ':&lt;remote name&gt;' to a 'filter unit' if the filter unit
 implies 'merged-remote' or 'gone-remote'. If there are filter units that are scoped, it trims merged or gone
 remote branches in the specified remote branch. If there are any filter unit that isn't scoped, it trims all
-merged or gone remote branches. [default : 'merged'] [config: trim.filter]</p>
+merged or gone remote branches. [default : 'merged:origin'] [config: trim.filter]</p>
 
 <p>-p, --protected &lt;protected&gt;...</p>
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -24,9 +24,12 @@ pub enum FilterUnit {
 pub struct DeleteFilter(HashSet<FilterUnit>);
 
 impl DeleteFilter {
-    pub fn merged() -> Self {
+    pub fn merged_origin() -> Self {
         use FilterUnit::*;
-        DeleteFilter::from_iter(vec![MergedLocal, MergedRemote(Scope::All)])
+        DeleteFilter::from_iter(vec![
+            MergedLocal,
+            MergedRemote(Scope::Scoped("origin".to_string())),
+        ])
     }
 
     pub fn all() -> Self {
@@ -282,7 +285,7 @@ pub struct Args {
     /// You can scope a filter unit to specific remote `:<remote name>` to a `filter unit` when the filter unit implies `merged-remote` or `gone-remote`.
     /// If there are filter units that are scoped, it trims remote branches only in the specified remote.
     /// If there are any filter unit that isn't scoped, it trims all remote branches.
-    /// [default : 'merged'] [config: trim.filter]
+    /// [default : 'merged:origin'] [config: trim.filter]
     #[structopt(short, long)]
     pub delete: Vec<DeleteFilter>,
 

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -91,6 +91,28 @@ pub struct RemoteBranch {
     pub refname: String,
 }
 
+impl RemoteBranch {
+    pub fn from_remote_tracking(repo: &Repository, remote_tracking: &str) -> Result<RemoteBranch> {
+        assert!(remote_tracking.starts_with("refs/remotes/"));
+        for remote_name in repo.remotes()?.iter() {
+            let remote_name = remote_name.context("non-utf8 remote name")?;
+            let remote = repo.find_remote(&remote_name)?;
+            if let Some(expanded) = expand_refspec(
+                &remote,
+                remote_tracking,
+                Direction::Fetch,
+                ExpansionSide::Left,
+            )? {
+                return Ok(RemoteBranch {
+                    remote: remote.name().context("non-utf8 remote name")?.to_string(),
+                    refname: expanded,
+                });
+            }
+        }
+        unreachable!("matching refspec is not found");
+    }
+}
+
 fn get_push_remote_branch(
     repo: &Repository,
     config: &Config,
@@ -140,21 +162,4 @@ fn get_push_remote_branch(
         "nothing" => unimplemented!("push.default=nothing is not implemented."),
         _ => panic!("unexpected config push.default"),
     }
-}
-
-pub fn get_remote_branch_from_ref(repo: &Repository, remote_ref: &str) -> Result<RemoteBranch> {
-    assert!(remote_ref.starts_with("refs/remotes/"));
-    for remote_name in repo.remotes()?.iter() {
-        let remote_name = remote_name.context("non-utf8 remote name")?;
-        let remote = repo.find_remote(&remote_name)?;
-        if let Some(expanded) =
-            expand_refspec(&remote, remote_ref, Direction::Fetch, ExpansionSide::Left)?
-        {
-            return Ok(RemoteBranch {
-                remote: remote.name().context("non-utf8 remote name")?.to_string(),
-                refname: expanded,
-            });
-        }
-    }
-    unreachable!("matching refspec is not found");
 }

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -74,7 +74,7 @@ pub fn get_push_upstream(
     branch: &str,
 ) -> Result<Option<String>> {
     if let Some(RemoteBranch {
-        remote_name,
+        remote: remote_name,
         refname,
     }) = get_push_remote_branch(repo, config, branch)?
     {
@@ -87,7 +87,7 @@ pub fn get_push_upstream(
 
 #[derive(Eq, PartialEq, Clone)]
 pub struct RemoteBranch {
-    pub remote_name: String,
+    pub remote: String,
     pub refname: String,
 }
 
@@ -111,7 +111,7 @@ fn get_push_remote_branch(
         expand_refspec(&remote, refname, Direction::Push, ExpansionSide::Right)?
     {
         return Ok(Some(RemoteBranch {
-            remote_name: remote_name.to_string(),
+            remote: remote_name.to_string(),
             refname: remote_branch,
         }));
     }
@@ -123,13 +123,13 @@ fn get_push_remote_branch(
 
     match push_default.as_str() {
         "current" => Ok(Some(RemoteBranch {
-            remote_name: remote_name.to_string(),
+            remote: remote_name.to_string(),
             refname: branch.to_string(),
         })),
         "upstream" | "tracking" | "simple" | "matching" => {
             if let Some(merge) = config::get_merge(config, &branch)? {
                 Ok(Some(RemoteBranch {
-                    remote_name: remote_name.clone(),
+                    remote: remote_name.clone(),
                     refname: merge,
                 }))
             } else {
@@ -151,7 +151,7 @@ pub fn get_remote_branch_from_ref(repo: &Repository, remote_ref: &str) -> Result
             expand_refspec(&remote, remote_ref, Direction::Fetch, ExpansionSide::Left)?
         {
             return Ok(RemoteBranch {
-                remote_name: remote.name().context("non-utf8 remote name")?.to_string(),
+                remote: remote.name().context("non-utf8 remote name")?.to_string(),
                 refname: expanded,
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl MergedOrGoneAndKeptBacks {
         let mut merged_remotes = HashSet::new();
         for remote_ref in &self.to_delete.merged_remotes {
             let remote_branch = get_remote_branch_from_ref(repo, remote_ref)?;
-            if filter.filter_merged_remote(&remote_branch.remote_name) {
+            if filter.filter_merged_remote(&remote_branch.remote) {
                 merged_remotes.insert(remote_ref.clone());
             } else {
                 trace!("filter-out: merged remote ref {}", remote_ref);
@@ -254,7 +254,7 @@ impl MergedOrGoneAndKeptBacks {
         let mut gone_remotes = HashSet::new();
         for remote_ref in &self.to_delete.gone_remotes {
             let ref_on_remote = get_remote_branch_from_ref(repo, remote_ref)?;
-            if filter.filter_gone_remote(&ref_on_remote.remote_name) {
+            if filter.filter_gone_remote(&ref_on_remote.remote) {
                 gone_remotes.insert(remote_ref.clone());
             } else {
                 trace!("filter-out: gone_remotes remote ref {}", remote_ref);
@@ -739,7 +739,7 @@ pub fn delete_remote_branches(
     for remote_ref in remote_refs {
         let ref_on_remote = get_remote_branch_from_ref(repo, remote_ref)?;
         let entry = per_remote
-            .entry(ref_on_remote.remote_name)
+            .entry(ref_on_remote.remote)
             .or_insert_with(Vec::new);
         entry.push(ref_on_remote.refname);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,7 @@ use log::*;
 use rayon::prelude::*;
 
 use crate::args::DeleteFilter;
-use crate::branch::{
-    get_fetch_upstream, get_push_upstream, get_remote, get_remote_branch_from_ref,
-};
+use crate::branch::{get_fetch_upstream, get_push_upstream, get_remote, RemoteBranch};
 use crate::subprocess::ls_remote_heads;
 pub use crate::subprocess::remote_update;
 
@@ -235,7 +233,7 @@ impl MergedOrGoneAndKeptBacks {
 
         let mut merged_remotes = HashSet::new();
         for remote_ref in &self.to_delete.merged_remotes {
-            let remote_branch = get_remote_branch_from_ref(repo, remote_ref)?;
+            let remote_branch = RemoteBranch::from_remote_tracking(repo, remote_ref)?;
             if filter.filter_merged_remote(&remote_branch.remote) {
                 merged_remotes.insert(remote_ref.clone());
             } else {
@@ -253,7 +251,7 @@ impl MergedOrGoneAndKeptBacks {
 
         let mut gone_remotes = HashSet::new();
         for remote_ref in &self.to_delete.gone_remotes {
-            let ref_on_remote = get_remote_branch_from_ref(repo, remote_ref)?;
+            let ref_on_remote = RemoteBranch::from_remote_tracking(repo, remote_ref)?;
             if filter.filter_gone_remote(&ref_on_remote.remote) {
                 gone_remotes.insert(remote_ref.clone());
             } else {
@@ -737,7 +735,7 @@ pub fn delete_remote_branches(
     }
     let mut per_remote = HashMap::new();
     for remote_ref in remote_refs {
-        let ref_on_remote = get_remote_branch_from_ref(repo, remote_ref)?;
+        let ref_on_remote = RemoteBranch::from_remote_tracking(repo, remote_ref)?;
         let entry = per_remote
             .entry(ref_on_remote.remote)
             .or_insert_with(Vec::new);

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main(args: Args) -> Result<()> {
         .expect("has default");
     let filter = config::get(&git.config, "trim.delete")
         .with_explicit("cli", flatten_collect(args.delete.clone()).into_option())
-        .with_default(&DeleteFilter::merged())
+        .with_default(&DeleteFilter::merged_origin())
         .parse_flatten()?
         .expect("has default");
 

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -182,17 +182,12 @@ pub fn branch_delete(repo: &Repository, branches: &[&str], dry_run: bool) -> Res
     }
 }
 
-pub fn push_delete(
-    repo: &Repository,
-    remote_name: &str,
-    remote_refnames: &[String],
-    dry_run: bool,
-) -> Result<()> {
+pub fn push_delete(repo: &Repository, remote: &str, refs: &[&String], dry_run: bool) -> Result<()> {
     let mut command = vec!["push", "--delete"];
     if dry_run {
         command.push("--dry-run");
     }
-    command.push(remote_name);
-    command.extend(remote_refnames.iter().map(String::as_str));
+    command.push(remote);
+    command.extend(refs.iter().map(|reference| reference.as_str()));
     git(repo, &command)
 }

--- a/tests/filter_accidential_track.rs
+++ b/tests/filter_accidential_track.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use git2::Repository;
 
 use git_trim::args::{DeleteFilter, FilterUnit, Scope};
-use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone};
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone, RemoteBranch};
 
 use fixture::{rc, Fixture};
 use std::iter::FromIterator;
@@ -95,7 +95,12 @@ fn test_default_config_tries_to_delete_accidential_track() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/contributer/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "contributer".to_string(),
+                    refname: "refs/heads/feature".to_string()
+                },
+            },
             ..Default::default()
         },
     );

--- a/tests/hub_cli_checkout.rs
+++ b/tests/hub_cli_checkout.rs
@@ -1,0 +1,120 @@
+mod fixture;
+
+use std::convert::TryFrom;
+
+use anyhow::Result;
+use git2::Repository;
+
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone, RemoteBranch};
+
+use fixture::{rc, Fixture};
+use git_trim::args::DeleteFilter;
+
+fn fixture() -> Fixture {
+    rc().append_fixture_trace(
+        r#"
+        git init upstream
+        upstream <<EOF
+            git config user.name "UpstreamTest"
+            git config user.email "upstream@test"
+            echo "Hello World!" > README.md
+            git add README.md
+            git commit -m "Initial commit"
+        EOF
+        git clone upstream origin -o upstream
+        origin <<EOF
+            git config user.name "Origin Test"
+            git config user.email "origin@test"
+            git config remote.pushdefault upstream
+        EOF
+        git clone origin local
+        local <<EOF
+            git config user.name "Local Test"
+            git config user.email "local@test"
+            git config remote.pushdefault origin
+            git config push.default simple
+            git remote add upstream ../upstream
+            git fetch upstream
+            git branch -u upstream/master master
+        EOF
+        origin <<EOF
+            git checkout -b feature
+            touch awesome-patch
+            git add awesome-patch
+            git commit -m "Awesome patch"
+            git push upstream feature:refs/pull/1/head
+            git checkout master
+        EOF
+        local <<EOF
+            git fetch ../origin feature:feature
+            git config branch.feature.remote "../origin"
+            git config branch.feature.merge "refs/heads/feature"
+        EOF
+        "#,
+    )
+}
+
+fn config() -> Config<'static> {
+    Config {
+        bases: vec!["master"],
+        protected_branches: set! {},
+        filter: DeleteFilter::all(),
+        detach: true,
+    }
+}
+
+#[test]
+fn test_accepted() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        upstream <<EOF
+            git merge refs/pull/1/head
+        EOF
+        # clicked delete branch button
+        origin <<EOF
+            git branch -D feature
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let branches = get_merged_or_gone(&git, &config())?;
+    assert_eq!(
+        branches.to_delete,
+        MergedOrGone {
+            merged_locals: set! {"feature"},
+            ..Default::default()
+        },
+    );
+    Ok(())
+}
+
+#[test]
+fn test_accepted_but_forgot_to_delete() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        upstream <<EOF
+            git merge refs/pull/1/head
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let branches = get_merged_or_gone(&git, &config())?;
+    assert_eq!(
+        branches.to_delete,
+        MergedOrGone {
+            merged_locals: set! {"feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "../origin".to_string(),
+                    refname: "refs/heads/feature".to_string(),
+                },
+            },
+            ..Default::default()
+        },
+    );
+    Ok(())
+}

--- a/tests/hub_cli_checkout.rs
+++ b/tests/hub_cli_checkout.rs
@@ -45,11 +45,6 @@ fn fixture() -> Fixture {
             git push upstream feature:refs/pull/1/head
             git checkout master
         EOF
-        local <<EOF
-            git fetch ../origin feature:feature
-            git config branch.feature.remote "../origin"
-            git config branch.feature.merge "refs/heads/feature"
-        EOF
         "#,
     )
 }
@@ -68,6 +63,11 @@ fn test_accepted() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
+        local <<EOF
+            git fetch ../origin feature:feature
+            git config branch.feature.remote "../origin"
+            git config branch.feature.merge "refs/heads/feature"
+        EOF
         upstream <<EOF
             git merge refs/pull/1/head
         EOF
@@ -95,6 +95,11 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
+        local <<EOF
+            git fetch ../origin feature:feature
+            git config branch.feature.remote "../origin"
+            git config branch.feature.merge "refs/heads/feature"
+        EOF
         upstream <<EOF
             git merge refs/pull/1/head
         EOF
@@ -113,6 +118,34 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
                     refname: "refs/heads/feature".to_string(),
                 },
             },
+            ..Default::default()
+        },
+    );
+    Ok(())
+}
+
+#[test]
+fn test_should_not_push_delete_non_heads() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        local <<EOF
+            git fetch ../upstream refs/pull/1/head:feature
+            git config branch.feature.remote "../origin"
+            git config branch.feature.merge "refs/pull/1/head"
+        EOF
+        upstream <<EOF
+            git merge refs/pull/1/head
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let branches = get_merged_or_gone(&git, &config())?;
+    assert_eq!(
+        branches.to_delete,
+        MergedOrGone {
+            merged_locals: set! {"feature"},
             ..Default::default()
         },
     );

--- a/tests/simple_git_flow.rs
+++ b/tests/simple_git_flow.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone};
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone, RemoteBranch};
 
 use fixture::{rc, Fixture};
 use git_trim::args::DeleteFilter;
@@ -106,7 +106,12 @@ fn test_feature_to_develop_but_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/origin/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/feature".to_string(),
+                },
+            },
             ..Default::default()
         },
     );
@@ -180,7 +185,12 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/origin/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/feature".to_string(),
+                },
+            },
             ..Default::default()
         },
     );
@@ -252,7 +262,12 @@ fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"hotfix"},
-            merged_remotes: set! {"refs/remotes/origin/hotfix"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/hotfix".to_string(),
+                },
+            },
             ..Default::default()
         },
     );

--- a/tests/simple_github_flow.rs
+++ b/tests/simple_github_flow.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone};
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone, RemoteBranch};
 
 use fixture::{rc, Fixture};
 use git_trim::args::DeleteFilter;
@@ -120,7 +120,12 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/origin/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/feature".to_string()
+                },
+            },
             ..Default::default()
         },
     );

--- a/tests/triangular_git_flow.rs
+++ b/tests/triangular_git_flow.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone};
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone, RemoteBranch};
 
 use fixture::{rc, Fixture};
 use git_trim::args::DeleteFilter;
@@ -131,7 +131,12 @@ fn test_feature_to_develop_but_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/origin/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/feature".to_string(),
+                },
+            },
             ..Default::default()
         },
     );
@@ -219,7 +224,12 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/origin/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/feature".to_string(),
+                },
+            },
             ..Default::default()
         },
     );
@@ -305,7 +315,12 @@ fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"hotfix"},
-            merged_remotes: set! {"refs/remotes/origin/hotfix"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/hotfix".to_string(),
+                },
+            },
             ..Default::default()
         },
     );

--- a/tests/triangular_github_flow.rs
+++ b/tests/triangular_github_flow.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone};
+use git_trim::{get_merged_or_gone, Config, Git, MergedOrGone, RemoteBranch};
 
 use fixture::{rc, Fixture};
 use git_trim::args::DeleteFilter;
@@ -143,7 +143,12 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
         branches.to_delete,
         MergedOrGone {
             merged_locals: set! {"feature"},
-            merged_remotes: set! {"refs/remotes/origin/feature"},
+            merged_remotes: set! {
+                RemoteBranch {
+                    remote: "origin".to_string(),
+                    refname: "refs/heads/feature".to_string(),
+                },
+            },
             ..Default::default()
         },
     );


### PR DESCRIPTION
TODO:
- [x] push delete hub-style checked-out branches
- [x] not `push delete origin` other than `refs/heads`
- [x] make `merged:origin` as a default option for `trim.delete` config.

Resolves: https://github.com/foriequal0/git-trim/issues/55