### PR TITLE
Skip printing summary when the `refs/remotes/*` do not have a refspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "textwrap",
+ "thiserror",
  "vergen",
 ]
 
@@ -875,6 +876,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
+dependencies = [
+ "proc-macro2 1.0.8",
+ "quote 1.0.2",
+ "syn 1.0.14",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ structopt = { version = "0.3", features = [ "paw" ] }
 anyhow = "1.0.26"
 glob = "0.3.0"
 rayon = "1.3.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ use log::*;
 use rayon::prelude::*;
 
 use crate::args::DeleteFilter;
-pub use crate::branch::RemoteBranch;
 use crate::branch::{get_fetch_upstream, get_push_upstream, get_remote};
+pub use crate::branch::{RemoteBranch, RemoteBranchError};
 use crate::subprocess::ls_remote_heads;
 pub use crate::subprocess::remote_update;
 


### PR DESCRIPTION
Resolves: https://github.com/foriequal0/git-trim/issues/73