### PR TITLE
Fix a crash on freshly cloned repository

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -206,6 +206,10 @@ fn should_update(repo: &Repository, interval: u64) -> Result<bool> {
     }
 
     let fetch_head = repo.path().join("FETCH_HEAD");
+    if !fetch_head.exists() {
+        return Ok(true);
+    }
+
     let metadata = std::fs::metadata(fetch_head)?;
     let elapsed = match metadata.modified()?.elapsed() {
         Ok(elapsed) => elapsed,


### PR DESCRIPTION
`FETCH_HEAD` doesn't exist when the repo is freshly cloned.

Resolves: https://github.com/foriequal0/git-trim/issues/78