### PR TITLE
Use remote `HEAD` branches as default base branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You might need to install `libssl-dev` and `pkg-config` packages if you build fr
 1. If you need more power, try `git trim --delete all`
 1. You can also `git trim --dry-run` when you don't trust me.
 
+#### Are you using git-flow?
+
+Don't forget to `git config trim.bases develop,master`.
+
 ## Why have you made this? Show me how it works.
 
 ### `git fetch --prune` doesn't do all the works for you

--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -26,11 +26,13 @@ Do not delete branches, show what branches will be deleted
 .SH OPTIONS
 .TP
 \fB\-b\fR, \fB\-\-bases\fR=\fIbases\fR
-Comma separated multiple names of branches. All the other branches are compared with the upstream branches of those branches. [default: master] [config: trim.bases]
+Comma separated multiple names of branches. All the other branches are compared with the upstream branches of those branches. [default: branches that tracks `git symbolic\-ref refs/remotes/*/HEAD`] [config: trim.bases]
+
+The default value is a branch that tracks `git symbolic\-ref refs/remotes/*/HEAD`. They might not be reflected correctly when the HEAD branch of your remote repository is changed. You can see the changed HEAD branch name with `git remote show <remote>` and apply it to your local repository with `git remote set\-head <remote> \-\-auto`.
 
 .TP
 \fB\-p\fR, \fB\-\-protected\fR=\fIprotected\fR
-Comma separated multiple glob patterns (e.g. `release\-*`, `feature/*`) of branches that should never be deleted. [default: <bases>] [config: trim.protected]
+Comma separated multiple glob patterns (e.g. `release\-*`, `feature/*`) of branches that should never be deleted. [config: trim.protected]
 
 .TP
 \fB\-\-update\-interval\fR=\fIupdate\-interval\fR

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -25,11 +25,17 @@ FLAGS
 OPTIONS
        -b, --bases=bases
               Comma separated multiple names of branches. All the other branches are compared with the upstream
-              branches of those branches. [default: master] [config: trim.bases]
+              branches of those branches. [default: branches that tracks `git symbolic-ref refs/remotes/*/HEAD`]
+              [config: trim.bases]
+
+              The default value is a branch that tracks `git symbolic-ref refs/remotes/*/HEAD`. They might not be
+              reflected correctly when the HEAD branch of your remote repository is changed. You can see the changed
+              HEAD branch name with `git remote show <remote>` and apply it to your local repository with `git remote
+              set-head <remote> --auto`.
 
        -p, --protected=protected
               Comma separated multiple glob patterns (e.g. `release-*`, `feature/*`) of branches that should never be
-              deleted. [default: <bases>] [config: trim.protected]
+              deleted. [config: trim.protected]
 
        --update-interval=update-interval
               Prevents too frequent updates. Seconds between updates in seconds. 0 to disable. [default: 5] [config:

--- a/src/args.rs
+++ b/src/args.rs
@@ -18,12 +18,17 @@ use clap::Clap;
 pub struct Args {
     /// Comma separated multiple names of branches.
     /// All the other branches are compared with the upstream branches of those branches.
-    /// [default: master] [config: trim.bases]
+    /// [default: branches that tracks `git symbolic-ref refs/remotes/*/HEAD`] [config: trim.bases]
+    ///
+    /// The default value is a branch that tracks `git symbolic-ref refs/remotes/*/HEAD`.
+    /// They might not be reflected correctly when the HEAD branch of your remote repository is changed.
+    /// You can see the changed HEAD branch name with `git remote show <remote>`
+    /// and apply it to your local repository with `git remote set-head <remote> --auto`.
     #[clap(short, long, value_delimiter = ",", aliases=&["base"])]
     pub bases: Vec<String>,
 
     /// Comma separated multiple glob patterns (e.g. `release-*`, `feature/*`) of branches that should never be deleted.
-    /// [default: <bases>] [config: trim.protected]
+    /// [config: trim.protected]
     #[clap(short, long, value_delimiter = ",")]
     pub protected: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ fn main(args: Args) -> Result<()> {
 
     let config = Config::read(&git.repo, &git.config, &args)?;
     info!("config: {:?}", config);
+    if config.bases.is_empty() {
+        return error_no_bases();
+    }
 
     if *config.update {
         if should_update(
@@ -78,6 +81,19 @@ fn main(args: Args) -> Result<()> {
     delete_remote_branches(&git.repo, &remotes, args.dry_run)?;
     delete_local_branches(&git.repo, &locals, args.dry_run)?;
     Ok(())
+}
+
+fn error_no_bases() -> Result<()> {
+    eprintln!(
+        "\
+No base branch is found! Try following any resolution:
+ * `git remote set-head origin --auto` will sync `refs/remotes/origin/HEAD` automatically.
+ * `git config trim.bases develop,master` will set base branches for git-trim for a repository.
+ * `git config --global trim.bases develop,master` will set base branches for `git-trim` globally.
+ * `git trim --bases develop,master` will temporarily set base branches for `git-trim`"
+    );
+
+    Err(anyhow::anyhow!("No base branch is found!").into())
 }
 
 pub fn print_summary(plan: &TrimPlan, repo: &Repository) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main(args: Args) -> Result<()> {
         return Err(anyhow::anyhow!("git-trim requires at least one remote").into());
     }
 
-    let config = Config::read(&git.config, &args)?;
+    let config = Config::read(&git.repo, &git.config, &args)?;
     info!("config: {:?}", config);
 
     if *config.update {

--- a/tests/filter_accidential_track.rs
+++ b/tests/filter_accidential_track.rs
@@ -58,7 +58,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/master"],
+        bases: vec!["master"],
         protected_branches: set! {},
         filter: DeleteFilter::from_iter(vec![
             FilterUnit::MergedLocal,

--- a/tests/hub_cli_checkout.rs
+++ b/tests/hub_cli_checkout.rs
@@ -51,7 +51,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/master"],
+        bases: vec!["master"],
         protected_branches: set! {},
         filter: DeleteFilter::all(),
         detach: true,

--- a/tests/merge_styles.rs
+++ b/tests/merge_styles.rs
@@ -45,7 +45,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/master"],
+        bases: vec!["master"],
         protected_branches: set! {},
         filter: DeleteFilter::all(),
         detach: true,

--- a/tests/simple_git_flow.rs
+++ b/tests/simple_git_flow.rs
@@ -38,7 +38,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/develop", "refs/heads/master"],
+        bases: vec!["develop", "master"], // Need to set bases manually for git flow
         protected_branches: set! {},
         filter: DeleteFilter::all(),
         detach: true,

--- a/tests/simple_github_flow.rs
+++ b/tests/simple_github_flow.rs
@@ -42,7 +42,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/master"],
+        bases: vec!["master"],
         protected_branches: set! {},
         filter: DeleteFilter::all(),
         detach: true,

--- a/tests/triangular_git_flow.rs
+++ b/tests/triangular_git_flow.rs
@@ -49,7 +49,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/develop", "refs/heads/master"],
+        bases: vec!["develop", "master"], // Need to set bases manually for git flow
         protected_branches: set! {},
         filter: DeleteFilter::all(),
         detach: true,

--- a/tests/triangular_github_flow.rs
+++ b/tests/triangular_github_flow.rs
@@ -51,7 +51,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["refs/heads/master"],
+        bases: vec!["master"],
         protected_branches: set! {},
         filter: DeleteFilter::all(),
         detach: true,


### PR DESCRIPTION
resolves: https://github.com/foriequal0/git-trim/issues/97

With this PR, `git-trim` will not use hard-coded default base branches anymore. It'll deduce a default base branch from `refs/remotes/*/HEAD`.

Previous default base branches `develop,master` were hardcoded for specifically for git-flow. git-flow users should set `git config trim.bases develop,master` in order to use as it was.