### PR TITLE
Don't protect any branches by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,6 @@ impl Config {
             .parses_and_collect::<CommaSeparatedSet<String>>()?;
         let protected = get(config, "trim.protected")
             .with_explicit("cli", non_empty(args.protected.clone()))
-            .with_default(vec![String::from("develop"), String::from("master")])
             .parses_and_collect::<CommaSeparatedSet<String>>()?;
         let update = get(config, "trim.update")
             .with_explicit("cli", args.update())


### PR DESCRIPTION
Previous default values were for fail safe and assumed some frequent base branch name candidates.
I think the fail safe can be removed now, and it is good to assume less about the repos branch name selections.