### PR TITLE
Classify non-tracking local branches and non-upstream remote-tracking branches too

### DIFF
--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -40,11 +40,13 @@ Prevents too frequent updates. Seconds between updates in seconds. 0 to disable.
 
 .TP
 \fB\-d\fR, \fB\-\-delete\fR=\fIdelete\fR
-Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged, local, remote, merged\-local, merged\-remote, stray, diverged`. You can scope a delete range to specific remote `:<remote name>` to a `delete range` when the delete range implies `merged\-remote` or `diverged`. [default : `merged:origin`] [config: trim.delete]
+Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged, merged\-local, merged\-remote, stray, diverged, local, remote`. You can scope a delete range to specific remote `:<remote name>` to a `delete range` when the delete range implies `merged\-remote` or `diverged` or `remote`. [default : `merged:origin`] [config: trim.delete]
 
 If there are delete ranges that are scoped, it trims remote branches only in the specified remote. If there are any delete range that isn`t scoped, it trims all remote branches.
 
-`all` implies `merged\-local,merged\-remote,stray\-local,stray\-remote`. `merged` implies `merged\-local,merged\-remote`. `local` implies `merged\-local,stray\-local`. `remote` implies `merged\-remote,stray\-remote`.
+`all` implies `merged,stray,diverged,local,remote`. `merged` implies `merged\-local,merged\-remote`.
+
+When `local` is specified, deletes non\-tracking merged local branches. When `remote` is specified, deletes non\-upstream remote tracking branches.
 .SH EXIT STATUS
 .TP
 \fB0\fR

--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -39,6 +39,14 @@ Comma separated multiple glob patterns (e.g. `release\-*`, `feature/*`) of branc
 Prevents too frequent updates. Seconds between updates in seconds. 0 to disable. [default: 5] [config: trim.updateInterval]
 
 .TP
+\fB\-s\fR, \fB\-\-scan\fR=\fIscan\fR
+Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local, remote`. You can scope a scan range to specific remote `:<remote name>` to a `scan range` when the scan range implies `remote`. [default : `local`] [config: trim.scan]
+
+When `local` is specified, scans tracking local branches, tracking its upstreams, and all non\-tracking merged local branches. When `remote` is specified, scans non\-upstream remote tracking branches. `all` implies `local,remote`.
+
+You might usually want to use one of these: `\-\-scan local` alone or `\-\-scan all:origin` with `\-\-delete merged:origin,remote:origin` option.
+
+.TP
 \fB\-d\fR, \fB\-\-delete\fR=\fIdelete\fR
 Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged, merged\-local, merged\-remote, stray, diverged, local, remote`. You can scope a delete range to specific remote `:<remote name>` to a `delete range` when the delete range implies `merged\-remote` or `diverged` or `remote`. [default : `merged:origin`] [config: trim.delete]
 

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -41,6 +41,18 @@ OPTIONS
               Prevents too frequent updates. Seconds between updates in seconds. 0 to disable. [default: 5] [config:
               trim.updateInterval]
 
+       -s, --scan=scan
+              Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local,
+              remote`. You can scope a scan range to specific remote `:<remote name>` to a `scan range` when the scan
+              range implies `remote`. [default : `local`] [config: trim.scan]
+
+              When `local` is specified, scans tracking local branches, tracking its upstreams, and all non-tracking
+              merged local branches. When `remote` is specified, scans non-upstream remote tracking branches. `all`
+              implies `local,remote`.
+
+              You might usually want to use one of these: `--scan local` alone or `--scan all:origin` with `--delete
+              merged:origin,remote:origin` option.
+
        -d, --delete=delete
               Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged,
               merged-local, merged-remote, stray, diverged, local, remote`. You can scope a delete range to specific

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -43,16 +43,17 @@ OPTIONS
 
        -d, --delete=delete
               Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged,
-              local, remote, merged-local, merged-remote, stray, diverged`. You can scope a delete range to specific
-              remote `:<remote name>` to a `delete range` when the delete range implies `merged-remote` or
-              `diverged`. [default : `merged:origin`] [config: trim.delete]
+              merged-local, merged-remote, stray, diverged, local, remote`. You can scope a delete range to specific
+              remote `:<remote name>` to a `delete range` when the delete range implies `merged-remote` or `diverged`
+              or `remote`. [default : `merged:origin`] [config: trim.delete]
 
               If there are delete ranges that are scoped, it trims remote branches only in the specified remote. If
               there are any delete range that isn`t scoped, it trims all remote branches.
 
-              `all` implies `merged-local,merged-remote,stray-local,stray-remote`. `merged` implies
-              `merged-local,merged-remote`. `local` implies `merged-local,stray-local`. `remote` implies
-              `merged-remote,stray-remote`.
+              `all` implies `merged,stray,diverged,local,remote`. `merged` implies `merged-local,merged-remote`.
+
+              When `local` is specified, deletes non-tracking merged local branches. When `remote` is specified,
+              deletes non-upstream remote tracking branches.
 
 EXIT STATUS
        0      Successful program execution.

--- a/src/args.rs
+++ b/src/args.rs
@@ -411,7 +411,7 @@ impl ScanRange {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ScanFilter(HashSet<ScanUnit>);
 
 impl ScanFilter {

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -147,6 +147,28 @@ impl Refname for RemoteTrackingBranch {
     }
 }
 
+impl<'repo> TryFrom<&git2::Branch<'repo>> for RemoteTrackingBranch {
+    type Error = anyhow::Error;
+
+    fn try_from(branch: &Branch<'repo>) -> Result<Self> {
+        let refname = branch.get().name().context("non-utf8 branch ref")?;
+        Ok(Self::new(refname))
+    }
+}
+
+impl<'repo> TryFrom<&git2::Reference<'repo>> for RemoteTrackingBranch {
+    type Error = anyhow::Error;
+
+    fn try_from(reference: &Reference<'repo>) -> Result<Self> {
+        if !reference.is_remote() {
+            anyhow::anyhow!("Reference {:?} is not a branch", reference.name());
+        }
+
+        let refname = reference.name().context("non-utf8 reference name")?;
+        Ok(Self::new(refname))
+    }
+}
+
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug)]
 pub struct RemoteBranch {
     pub remote: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use git2::{BranchType, Config as GitConfig, Error, ErrorClass, ErrorCode, Remote, Repository};
 use log::*;
 
-use crate::args::{Args, DeleteFilter, DeleteRange};
+use crate::args::{Args, DeleteFilter, DeleteRange, ScanFilter, ScanRange};
 use crate::branch::LocalBranch;
 use std::collections::HashSet;
 
@@ -22,6 +22,7 @@ pub struct Config {
     pub update_interval: ConfigValue<u64>,
     pub confirm: ConfigValue<bool>,
     pub detach: ConfigValue<bool>,
+    pub scan: ConfigValue<ScanFilter>,
     pub delete: ConfigValue<DeleteFilter>,
 }
 
@@ -62,6 +63,10 @@ impl Config {
             .with_default(true)
             .read()?
             .expect("has default");
+        let scan = get_comma_separated_multi(config, "trim.scan")
+            .with_explicit("cli", non_empty(args.scan.clone()))
+            .with_default(ScanRange::local())
+            .parses_and_collect::<ScanFilter>()?;
         let delete = get_comma_separated_multi(config, "trim.delete")
             .with_explicit("cli", non_empty(args.delete.clone()))
             .with_default(DeleteRange::merged_origin())
@@ -74,6 +79,7 @@ impl Config {
             update_interval,
             confirm,
             detach,
+            scan,
             delete,
         })
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -235,14 +235,8 @@ impl TrimPlan {
 
     pub fn get_preserved_upstream(&self, target: &RemoteTrackingBranch) -> Option<&Preserved> {
         for preserved in &self.preserved {
-            match &preserved.branch {
-                ClassifiedBranch::MergedRemoteTracking(upstream)
-                | ClassifiedBranch::DivergedRemoteTracking { upstream, .. } => {
-                    if upstream == target {
-                        return Some(preserved);
-                    }
-                }
-                _ => {}
+            if preserved.branch.upstream() == Some(target) {
+                return Some(preserved);
             }
         }
         None

--- a/src/core.rs
+++ b/src/core.rs
@@ -324,11 +324,10 @@ impl ClassifiedBranch {
 
     pub fn message_local(&self) -> String {
         match self {
-            ClassifiedBranch::MergedLocal(_)
-            | ClassifiedBranch::MergedRemoteTracking(_)
-            | ClassifiedBranch::MergedDirectFetch { .. }
-            | ClassifiedBranch::MergedNonTrackingLocal(_)
-            | ClassifiedBranch::MergedNonUpstreamRemoteTracking(_) => "merged".to_owned(),
+            ClassifiedBranch::MergedLocal(_) | ClassifiedBranch::MergedDirectFetch { .. } => {
+                "merged".to_owned()
+            }
+            ClassifiedBranch::MergedNonTrackingLocal(_) => "merged non-tracking".to_owned(),
             ClassifiedBranch::Stray(_) => "stray".to_owned(),
             ClassifiedBranch::DivergedRemoteTracking {
                 upstream: remote, ..
@@ -336,23 +335,24 @@ impl ClassifiedBranch {
             ClassifiedBranch::DivergedDirectFetch { remote, .. } => {
                 format!("diverged with {}", remote)
             }
+            _ => "If you see this message, report this as a bug".to_owned(),
         }
     }
 
     pub fn message_remote(&self) -> String {
         match self {
-            ClassifiedBranch::MergedLocal(_)
-            | ClassifiedBranch::MergedRemoteTracking(_)
-            | ClassifiedBranch::MergedDirectFetch { .. }
-            | ClassifiedBranch::MergedNonTrackingLocal(_)
-            | ClassifiedBranch::MergedNonUpstreamRemoteTracking(_) => "merged".to_owned(),
-            ClassifiedBranch::Stray(_) => "stray".to_owned(),
+            ClassifiedBranch::MergedRemoteTracking(_)
+            | ClassifiedBranch::MergedDirectFetch { .. } => "merged".to_owned(),
+            ClassifiedBranch::MergedNonUpstreamRemoteTracking(_) => {
+                "merged non-upstream".to_owned()
+            }
             ClassifiedBranch::DivergedRemoteTracking { local, .. } => {
                 format!("diverged with {}", local.refname)
             }
             ClassifiedBranch::DivergedDirectFetch { local, .. } => {
                 format!("diverged with {}", local.short_name())
             }
+            _ => "If you see this message, report this as a bug".to_owned(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ use log::*;
 
 use crate::args::DeleteFilter;
 pub use crate::branch::{LocalBranch, RemoteBranch, RemoteBranchError, RemoteTrackingBranch};
-use crate::core::{get_remote_heads, get_tracking_branches, MergeTracker};
+use crate::core::{
+    get_non_tracking_local_branches, get_non_upstream_remote_tracking_branches, get_remote_heads,
+    get_tracking_branches, MergeTracker,
+};
 pub use crate::core::{ClassifiedBranch, TrimPlan};
 pub use crate::subprocess::{ls_remote_head, remote_update, RemoteHead};
 pub use crate::util::ForceSendSync;
@@ -52,37 +55,77 @@ pub fn get_trim_plan(git: &Git, param: &PlanParam) -> Result<TrimPlan> {
 
     let merge_tracker = MergeTracker::with_base_upstreams(&git.repo, &git.config, &base_upstreams)?;
     let tracking_branches = get_tracking_branches(git, &base_upstreams)?;
+    let non_tracking_branches = get_non_tracking_local_branches(git, &base_refs)?;
+    let non_upstream_branches = get_non_upstream_remote_tracking_branches(git, &base_upstreams)?;
     let remote_heads = get_remote_heads(git)?;
 
     info!("Start classify:");
     let classifications;
+    let non_trackings;
+    let non_upstreams;
     {
         // git's fields are semantically Send + Sync in the `classify`.
         // They are read only in `classify` function.
         // It is denoted that it is safe in that case
         // https://github.com/libgit2/libgit2/blob/master/docs/threading.md#sharing-objects
         let git = ForceSendSync::new(git);
+        let repo = ForceSendSync::new(&git.repo);
         let merge_tracker = &merge_tracker;
+
         let base_upstreams = &base_upstreams;
         let tracking_branches = &tracking_branches;
+        let non_tracking_branches = &non_tracking_branches;
+        let non_upstream_branches = &non_upstream_branches;
         let remote_heads = &remote_heads;
+
         let (classification_tx, classification_rx) = channel();
+        let (non_tracking_tx, non_tracking_rx) = channel();
+        let (non_upstream_tx, non_upstream_rx) = channel();
+
         rayon::scope(move |s| {
             for base in base_upstreams {
                 for branch in tracking_branches {
                     let tx = classification_tx.clone();
                     s.spawn(move |_| {
                         let c = core::classify(git, merge_tracker, remote_heads, base, branch)
-                            .with_context(|| format!("base={:?}, branch={:?}", base, branch));
-                        tx.send(c).unwrap();
+                            .with_context(|| {
+                                format!("tracking, base={:?}, branch={:?}", base, branch)
+                            });
+                        tx.send(c).expect("in scope");
                     });
+                }
+
+                for branch in non_tracking_branches {
+                    let tx = non_tracking_tx.clone();
+                    s.spawn(move |_| {
+                        let result = merge_tracker
+                            .check_and_track(&repo, &base.refname, branch)
+                            .with_context(|| {
+                                format!("non-tracking, base={:?}, branch={:?}", base, branch)
+                            });
+                        tx.send(result).expect("in scope");
+                    })
+                }
+
+                for branch in non_upstream_branches {
+                    let tx = non_upstream_tx.clone();
+                    s.spawn(move |_| {
+                        let result = merge_tracker
+                            .check_and_track(&repo, &base.refname, branch)
+                            .with_context(|| {
+                                format!("non-upstream, base={:?}, branch={:?}", base, branch)
+                            });
+                        tx.send(result).expect("in scope");
+                    })
                 }
             }
         });
 
         classifications = classification_rx
             .into_iter()
-            .collect::<Result<Vec<_>, _>>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        non_trackings = non_tracking_rx.into_iter().collect::<Result<Vec<_>, _>>()?;
+        non_upstreams = non_upstream_rx.into_iter().collect::<Result<Vec<_>, _>>()?;
     };
 
     let mut delete = HashSet::new();
@@ -91,6 +134,22 @@ pub fn get_trim_plan(git: &Git, param: &PlanParam) -> Result<TrimPlan> {
         trace!("fetch: {:?}", classification.fetch);
         debug!("message: {:?}", classification.messages);
         delete.extend(classification.result.into_iter());
+    }
+    for non_tracking in non_trackings.into_iter() {
+        debug!("non-tracking: {:?}", non_tracking);
+        if non_tracking.merged {
+            delete.insert(ClassifiedBranch::MergedNonTrackingLocal(
+                non_tracking.branch,
+            ));
+        }
+    }
+    for non_upstream in non_upstreams.into_iter() {
+        debug!("non-upstream: {:?}", non_upstream);
+        if non_upstream.merged {
+            delete.insert(ClassifiedBranch::MergedNonUpstreamRemoteTracking(
+                non_upstream.branch,
+            ));
+        }
     }
 
     let mut result = TrimPlan {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ fn main(args: Args) -> Result<()> {
         &PlanParam {
             bases: config.bases.iter().map(String::as_str).collect(),
             protected_branches: config.protected.iter().map(String::as_str).collect(),
+            scan: config.scan.clone(),
             delete: config.delete.clone(),
             detach: *config.detach,
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,13 @@ pub fn print_summary(plan: &TrimPlan, repo: &Repository) -> Result<()> {
                 merged_locals.push(local.short_name().to_owned());
                 diverged_remotes.push(remote.to_string())
             }
+            ClassifiedBranch::MergedNonTrackingLocal(local) => {
+                merged_locals.push(format!("{} (non-tracking)", local.short_name()));
+            }
+            ClassifiedBranch::MergedNonUpstreamRemoteTracking(upstream) => {
+                let remote = upstream.to_remote_branch(repo)?;
+                merged_remotes.push(format!("{} (non-upstream)", remote.to_string()));
+            }
         }
     }
 

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -8,7 +8,7 @@ use std::thread::spawn;
 use log::*;
 use tempfile::{tempdir, TempDir};
 
-use git_trim::args::{DeleteFilter, DeleteRange, Scope};
+use git_trim::args::{DeleteFilter, DeleteRange, ScanFilter, ScanRange, Scope};
 use git_trim::PlanParam;
 
 #[derive(Default)]
@@ -205,6 +205,7 @@ pub fn test_default_param() -> PlanParam<'static> {
     PlanParam {
         bases: vec!["master"],
         protected_branches: set! {},
+        scan: ScanFilter::from_iter(vec![ScanRange::Local]),
         delete: DeleteFilter::from_iter(vec![
             MergedLocal,
             MergedRemote(Scope::All),

--- a/tests/non_trackings_non_upstreams.rs
+++ b/tests/non_trackings_non_upstreams.rs
@@ -1,11 +1,15 @@
 mod fixture;
 
 use std::convert::TryFrom;
+use std::iter::FromIterator;
 
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteTrackingBranch};
+use git_trim::args::{ScanFilter, ScanRange, Scope};
+use git_trim::{
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
+};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -39,6 +43,13 @@ fn fixture() -> Fixture {
     )
 }
 
+fn param() -> PlanParam<'static> {
+    PlanParam {
+        scan: ScanFilter::from_iter(vec![ScanRange::All(Scope::All)]),
+        ..test_default_param()
+    }
+}
+
 #[test]
 fn test_merged_non_tracking() -> Result<()> {
     let guard = fixture().prepare(
@@ -53,7 +64,7 @@ fn test_merged_non_tracking() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(&git, &param())?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -81,7 +92,7 @@ fn test_merged_non_upstream() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(&git, &param())?;
     assert_eq!(
         plan.to_delete,
         set! {

--- a/tests/non_trackings_non_upstreams.rs
+++ b/tests/non_trackings_non_upstreams.rs
@@ -1,0 +1,92 @@
+mod fixture;
+
+use std::convert::TryFrom;
+
+use anyhow::Result;
+use git2::Repository;
+
+use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteTrackingBranch};
+
+use fixture::{rc, test_default_param, Fixture};
+
+fn fixture() -> Fixture {
+    rc().append_fixture_trace(
+        r#"
+        git init origin
+        origin <<EOF
+            git config user.name "Origin Test"
+            git config user.email "origin@test"
+            echo "Hello World!" > README.md
+            git add README.md
+            git commit -m "Initial commit"
+        EOF
+        git clone origin local
+        local <<EOF
+            git config user.name "Local Test"
+            git config user.email "local@test"
+            git config remote.pushdefault origin
+            git config push.default simple
+        EOF
+        # prepare awesome patch
+        local <<EOF
+            git checkout -b feature
+            touch awesome-patch
+            git add awesome-patch
+            git commit -m "Awesome patch"
+            git push origin feature
+        EOF
+        "#,
+    )
+}
+
+#[test]
+fn test_merged_non_tracking() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        origin <<EOF
+            git checkout master
+            git merge feature
+            git branch -d feature
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let plan = get_trim_plan(&git, &test_default_param())?;
+    assert_eq!(
+        plan.to_delete,
+        set! {
+            ClassifiedBranch::MergedNonTrackingLocal(LocalBranch::new("refs/heads/feature")),
+        },
+    );
+    Ok(())
+}
+
+#[test]
+fn test_merged_non_upstream() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        origin <<EOF
+            git config core.bare true
+        EOF
+        local <<EOF
+            git checkout master
+            git merge feature
+            git branch -D feature
+            git push origin master
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let plan = get_trim_plan(&git, &test_default_param())?;
+    assert_eq!(
+        plan.to_delete,
+        set! {
+            ClassifiedBranch::MergedNonUpstreamRemoteTracking(RemoteTrackingBranch::new("refs/remotes/origin/feature")),
+        },
+    );
+    Ok(())
+}


### PR DESCRIPTION
**breaking change**
This PR repurposes `--delete local`, and `--delete remote` flags. I think that they are rarely used, and it is good to reduce combinatorial complexities of the `--delete` flag.

resolves: https://github.com/foriequal0/git-trim/issues/137