### PR TITLE
Require a scope for ranges

### DIFF
--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -40,21 +40,19 @@ Prevents too frequent updates. Seconds between updates in seconds. 0 to disable.
 
 .TP
 \fB\-s\fR, \fB\-\-scan\fR=\fIscan\fR
-Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local, remote`. You can scope a scan range to specific remote `:<remote name>` to a `scan range` when the scan range implies `remote`. [default : `local`] [config: trim.scan]
+Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local, remote`. `:<remote name>` is necessary to a `<scan range>` when the scan range implies `remote`. You can use `*` as `<remote name>` to scan branches from all remotes. [default : `local`] [config: trim.scan]
 
-When `local` is specified, scans tracking local branches, tracking its upstreams, and all non\-tracking merged local branches. When `remote` is specified, scans non\-upstream remote tracking branches. `all` implies `local,remote`.
+When `local` is specified, scans tracking local branches, tracking its upstreams, and all non\-tracking local branches. When `remote:<remote name>` is specified, scans non\-upstream remote tracking branches from `<remote name>`. `all` implies `local,remote`.
 
 You might usually want to use one of these: `\-\-scan local` alone or `\-\-scan all:origin` with `\-\-delete merged:origin,remote:origin` option.
 
 .TP
 \fB\-d\fR, \fB\-\-delete\fR=\fIdelete\fR
-Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged, merged\-local, merged\-remote, stray, diverged, local, remote`. You can scope a delete range to specific remote `:<remote name>` to a `delete range` when the delete range implies `merged\-remote` or `diverged` or `remote`. [default : `merged:origin`] [config: trim.delete]
-
-If there are delete ranges that are scoped, it trims remote branches only in the specified remote. If there are any delete range that isn`t scoped, it trims all remote branches.
+Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged, merged\-local, merged\-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged\-remote`, `diverged` or `remote`. You can use `*` as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
 
 `all` implies `merged,stray,diverged,local,remote`. `merged` implies `merged\-local,merged\-remote`.
 
-When `local` is specified, deletes non\-tracking merged local branches. When `remote` is specified, deletes non\-upstream remote tracking branches.
+When `local` is specified, deletes non\-tracking merged local branches. When `remote` is specified, deletes non\-upstream merged remote tracking branches.
 .SH EXIT STATUS
 .TP
 \fB0\fR

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -43,29 +43,28 @@ OPTIONS
 
        -s, --scan=scan
               Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local,
-              remote`. You can scope a scan range to specific remote `:<remote name>` to a `scan range` when the scan
-              range implies `remote`. [default : `local`] [config: trim.scan]
+              remote`. `:<remote name>` is necessary to a `<scan range>` when the scan range implies `remote`. You
+              can use `*` as `<remote name>` to scan branches from all remotes. [default : `local`] [config:
+              trim.scan]
 
               When `local` is specified, scans tracking local branches, tracking its upstreams, and all non-tracking
-              merged local branches. When `remote` is specified, scans non-upstream remote tracking branches. `all`
-              implies `local,remote`.
+              local branches. When `remote:<remote name>` is specified, scans non-upstream remote tracking branches
+              from `<remote name>`. `all` implies `local,remote`.
 
               You might usually want to use one of these: `--scan local` alone or `--scan all:origin` with `--delete
               merged:origin,remote:origin` option.
 
        -d, --delete=delete
               Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged,
-              merged-local, merged-remote, stray, diverged, local, remote`. You can scope a delete range to specific
-              remote `:<remote name>` to a `delete range` when the delete range implies `merged-remote` or `diverged`
-              or `remote`. [default : `merged:origin`] [config: trim.delete]
-
-              If there are delete ranges that are scoped, it trims remote branches only in the specified remote. If
-              there are any delete range that isn`t scoped, it trims all remote branches.
+              merged-local, merged-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a
+              `<delete range>` when the delete range implies `merged-remote`, `diverged` or `remote`. You can use `*`
+              as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config:
+              trim.delete]
 
               `all` implies `merged,stray,diverged,local,remote`. `merged` implies `merged-local,merged-remote`.
 
               When `local` is specified, deletes non-tracking merged local branches. When `remote` is specified,
-              deletes non-upstream remote tracking branches.
+              deletes non-upstream merged remote tracking branches.
 
 EXIT STATUS
        0      Successful program execution.


### PR DESCRIPTION
**Breaking Change**
Previous: `--delete all` meant "I don't care where the branch is came from"
Now: `--delete all` is prohibited. You should use specify `--delete all:origin` or explicitly `--delete 'all:*'`

I'm thinking about detecting default remotes from `refs/remotes/*/HEAD`. `--delete all` might use them.