### PR TITLE
Fetch remote heads concurrently

### DIFF
--- a/src/remote_heads_prefetcher.rs
+++ b/src/remote_heads_prefetcher.rs
@@ -1,0 +1,78 @@
+use std::convert::TryFrom;
+use std::thread::JoinHandle;
+
+use anyhow::{Context, Result};
+use crossbeam_channel::unbounded;
+use git2::BranchType;
+
+use crate::{config, subprocess, ForceSendSync, Git, LocalBranch, RemoteHead};
+
+pub enum RemoteHeadsPrefetcher {
+    Fetching(JoinHandle<Vec<Result<Vec<RemoteHead>>>>),
+    Noop,
+}
+
+impl RemoteHeadsPrefetcher {
+    pub fn noop() -> Self {
+        RemoteHeadsPrefetcher::Noop
+    }
+
+    pub fn spawn(git: &Git) -> Result<Self> {
+        let remote_urls = get_remote_urls(git)?;
+        if remote_urls.is_empty() {
+            return Ok(Self::Noop);
+        }
+
+        let git = ForceSendSync::new(git).as_static();
+        let join_handle = std::thread::spawn(move || {
+            let (branches_sender, branches_receiver) = unbounded();
+            rayon::scope(move |scope| {
+                for remote_url in remote_urls {
+                    let branches_sender = branches_sender.clone();
+                    scope.spawn(move |_| {
+                        let result = subprocess::ls_remote_heads(&git.repo, &remote_url)
+                            .with_context(|| format!("remote_url={}", remote_url));
+                        branches_sender.send(result).unwrap();
+                    });
+                }
+            });
+            branches_receiver.iter().collect()
+        });
+
+        Ok(Self::Fetching(join_handle))
+    }
+
+    pub fn get(self) -> Result<Vec<RemoteHead>> {
+        match self {
+            RemoteHeadsPrefetcher::Fetching(join_handle) => {
+                let mut result = Vec::new();
+                for heads in join_handle.join().unwrap() {
+                    result.extend(heads?);
+                }
+                Ok(result)
+            }
+            RemoteHeadsPrefetcher::Noop => Ok(Vec::new()),
+        }
+    }
+}
+
+fn get_remote_urls(git: &Git) -> Result<Vec<String>> {
+    let mut result = Vec::new();
+    for branch in git.repo.branches(Some(BranchType::Local))? {
+        let local = LocalBranch::try_from(&branch?.0)?;
+
+        let remote = if let Some(remote) = config::get_remote_name(&git.config, &local)? {
+            remote
+        } else {
+            continue;
+        };
+
+        if config::get_remote(&git.repo, &remote)?.is_some() {
+            continue;
+        }
+
+        result.push(remote);
+    }
+
+    Ok(result)
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,12 @@ impl<T> ForceSendSync<T> {
     }
 }
 
+impl<'a, T> ForceSendSync<&'a T> {
+    pub fn as_static(self) -> ForceSendSync<&'static T> {
+        unsafe { ForceSendSync(std::mem::transmute::<&'a T, &'static T>(self.0)) }
+    }
+}
+
 impl<T> Deref for ForceSendSync<T> {
     type Target = T;
 

--- a/tests/filter_accidential_track.rs
+++ b/tests/filter_accidential_track.rs
@@ -8,7 +8,8 @@ use git2::Repository;
 
 use git_trim::args::{DeleteFilter, DeleteRange, Scope};
 use git_trim::{
-    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteHeadsPrefetcher,
+    RemoteTrackingBranch,
 };
 
 use fixture::{rc, test_default_param, Fixture};
@@ -85,6 +86,7 @@ fn test_default_config_tries_to_delete_accidential_track() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             delete: DeleteFilter::from_iter(vec![
                 DeleteRange::MergedLocal,
@@ -124,7 +126,7 @@ fn test_accidential_track() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
     assert_eq!(
         plan.to_delete,
         set! {

--- a/tests/hub_cli_checkout.rs
+++ b/tests/hub_cli_checkout.rs
@@ -5,7 +5,9 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteBranch};
+use git_trim::{
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteBranch, RemoteHeadsPrefetcher,
+};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -61,7 +63,11 @@ fn test_noop() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(plan.to_delete, set! {});
     Ok(())
 }
@@ -88,7 +94,11 @@ fn test_accepted() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -115,7 +125,11 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -159,7 +173,11 @@ fn test_modified_and_accepted() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -192,7 +210,11 @@ fn test_modified_and_accepted_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -227,7 +249,11 @@ fn test_rejected() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -254,7 +280,11 @@ fn test_should_not_push_delete_non_heads() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {

--- a/tests/merge_styles.rs
+++ b/tests/merge_styles.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch};
+use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteHeadsPrefetcher};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -56,7 +56,11 @@ fn test_noff() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -82,7 +86,11 @@ fn test_rebase() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -106,7 +114,11 @@ fn test_squash() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -180,7 +192,11 @@ fn test_mixed() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {

--- a/tests/non_trackings_non_upstreams.rs
+++ b/tests/non_trackings_non_upstreams.rs
@@ -8,7 +8,8 @@ use git2::Repository;
 
 use git_trim::args::{ScanFilter, ScanRange, Scope};
 use git_trim::{
-    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteHeadsPrefetcher,
+    RemoteTrackingBranch,
 };
 
 use fixture::{rc, test_default_param, Fixture};
@@ -64,7 +65,7 @@ fn test_merged_non_tracking() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -92,7 +93,7 @@ fn test_merged_non_upstream() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
     assert_eq!(
         plan.to_delete,
         set! {

--- a/tests/orphan.rs
+++ b/tests/orphan.rs
@@ -7,8 +7,7 @@ use anyhow::Result;
 use git2::Repository;
 
 use git_trim::args::{DeleteFilter, DeleteRange, Scope};
-
-use git_trim::{get_trim_plan, Git, PlanParam};
+use git_trim::{get_trim_plan, Git, PlanParam, RemoteHeadsPrefetcher};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -51,6 +50,7 @@ fn test_bases_implicit_value() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             delete: DeleteFilter::from_iter(vec![
                 DeleteRange::MergedLocal,

--- a/tests/simple_git_flow.rs
+++ b/tests/simple_git_flow.rs
@@ -6,7 +6,8 @@ use anyhow::Result;
 use git2::Repository;
 
 use git_trim::{
-    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteHeadsPrefetcher,
+    RemoteTrackingBranch,
 };
 
 use fixture::{rc, test_default_param, Fixture};
@@ -66,7 +67,7 @@ fn test_feature_to_develop() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -98,7 +99,7 @@ fn test_feature_to_develop_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -135,7 +136,7 @@ fn test_develop_to_master() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -170,7 +171,7 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -206,7 +207,7 @@ fn test_hotfix_to_master() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -240,7 +241,7 @@ fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -272,7 +273,7 @@ fn test_rejected_feature_to_develop() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -305,7 +306,7 @@ fn test_rejected_hotfix_to_master() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -340,6 +341,7 @@ fn test_protected_feature_to_develop() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/feature"},
             ..param()
@@ -377,6 +379,7 @@ fn test_protected_feature_to_master() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/feature"},
             ..param()
@@ -409,6 +412,7 @@ fn test_rejected_protected_feature_to_develop() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/feature"},
             ..param()
@@ -433,6 +437,7 @@ fn test_protected_branch_shouldnt_be_stray() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/master", "refs/heads/develop"},
             ..param()

--- a/tests/simple_github_flow.rs
+++ b/tests/simple_github_flow.rs
@@ -5,7 +5,9 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteTrackingBranch};
+use git_trim::{
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteHeadsPrefetcher, RemoteTrackingBranch,
+};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -53,7 +55,11 @@ fn test_accepted() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -81,7 +87,11 @@ fn test_accepted_but_edited() -> Result<()> {
         "#,
     )?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -103,7 +113,11 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
         "#,
     )?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -131,7 +145,11 @@ fn test_accepted_but_forgot_to_delete_and_edited() -> Result<()> {
         "#,
     )?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -153,7 +171,11 @@ fn test_rejected() -> Result<()> {
     "#,
     )?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -179,7 +201,11 @@ fn test_rejected_but_edited() -> Result<()> {
     "#,
     )?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -193,7 +219,11 @@ fn test_rejected_but_edited() -> Result<()> {
 fn test_rejected_but_forgot_to_delete() -> Result<()> {
     let guard = fixture().prepare("local", r#""#)?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(plan.to_delete, set! {});
     Ok(())
 }
@@ -211,7 +241,11 @@ fn test_rejected_but_forgot_to_delete_and_edited() -> Result<()> {
     "#,
     )?;
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(plan.to_delete, set! {});
     Ok(())
 }

--- a/tests/triangular_git_flow.rs
+++ b/tests/triangular_git_flow.rs
@@ -6,7 +6,8 @@ use anyhow::Result;
 use git2::Repository;
 
 use git_trim::{
-    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteHeadsPrefetcher,
+    RemoteTrackingBranch,
 };
 
 use fixture::{rc, test_default_param, Fixture};
@@ -86,7 +87,7 @@ fn test_feature_to_develop() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -123,7 +124,7 @@ fn test_feature_to_develop_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -169,7 +170,7 @@ fn test_develop_to_master() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -209,7 +210,7 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -254,7 +255,7 @@ fn test_hotfix_to_master() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -293,7 +294,7 @@ fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -331,7 +332,7 @@ fn test_rejected_feature_to_develop() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -370,7 +371,7 @@ fn test_rejected_hotfix_to_master() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &param())?;
+    let plan = get_trim_plan(&git, RemoteHeadsPrefetcher::spawn(&git)?, &param())?;
 
     assert_eq!(
         plan.to_delete,
@@ -414,6 +415,7 @@ fn test_protected_feature_to_develop() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/feature"},
             ..param()
@@ -460,6 +462,7 @@ fn test_protected_feature_to_master() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/feature"},
             ..param()
@@ -498,6 +501,7 @@ fn test_rejected_protected_feature_to_develop() -> Result<()> {
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
     let plan = get_trim_plan(
         &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
         &PlanParam {
             protected_branches: set! {"refs/heads/feature"},
             ..param()

--- a/tests/triangular_github_flow.rs
+++ b/tests/triangular_github_flow.rs
@@ -5,7 +5,9 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteTrackingBranch};
+use git_trim::{
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteHeadsPrefetcher, RemoteTrackingBranch,
+};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -67,7 +69,11 @@ fn test_accepted() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -101,7 +107,11 @@ fn test_accepted_but_edited() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -126,7 +136,11 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -157,7 +171,11 @@ fn test_accepted_but_forgot_to_delete_and_edited() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -181,7 +199,11 @@ fn test_rejected() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -209,7 +231,11 @@ fn test_rejected_but_edited() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(
         plan.to_delete,
         set! {
@@ -231,7 +257,11 @@ fn test_rejected_but_forgot_to_delete() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(plan.to_delete, set! {});
     Ok(())
 }
@@ -253,7 +283,11 @@ fn test_rejected_but_forgot_to_delete_and_edited() -> Result<()> {
     )?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
     assert_eq!(plan.to_delete, set! {});
     Ok(())
 }

--- a/tests/worktree.rs
+++ b/tests/worktree.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch};
+use git_trim::{get_trim_plan, ClassifiedBranch, Git, LocalBranch, RemoteHeadsPrefetcher};
 
 use fixture::{rc, test_default_param, Fixture};
 
@@ -49,7 +49,11 @@ fn test_bases_implicit_value() -> Result<()> {
     let guard = fixture().prepare("local", r#""#)?;
 
     let git = Git::try_from(Repository::open(guard.working_directory())?)?;
-    let plan = get_trim_plan(&git, &test_default_param())?;
+    let plan = get_trim_plan(
+        &git,
+        RemoteHeadsPrefetcher::spawn(&git)?,
+        &test_default_param(),
+    )?;
 
     assert!(plan.preserved.iter().any(|w| {
         w.branch == ClassifiedBranch::MergedLocal(LocalBranch::new("refs/heads/worktree"))


### PR DESCRIPTION
It fires following jobs concurrently, which ran sequentially.

 * `git remote update --prune`
 * `git ls-remote --heads <remote url>`