### PR TITLE
Remove `--scan` flag and `--delete all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ You might need to install `libssl-dev` and `pkg-config` packages if you build fr
 1. Don't forget to set an upstream for a branch that you want to trim automatically.
    `git push -u <remote> <branch>` will set an upstream for you on push.
 1. Run `git trim` if you need to trim branches especially after PR reviews. It'll automatically recognize merged or stray branches, and delete it.
-1. If you need more power, try `git trim --delete all`
 1. You can also `git trim --dry-run` when you don't trust me.
 
 #### Are you using git-flow?
@@ -114,7 +113,7 @@ Not because `--force` is dangerous. Just `gone` doesn't mean it is fully merged 
  I've spent about half of the code on scenario tests. I wanted to make sure that it doesn't delete unmerged contents accidentally in any case.
  * It supports github flow (master-feature tiered branch strategy), git flow (master-develop-feature tiered branch strategy),
  and simple workflow (with a remote repo and a local clone), and triangular workflow (with two remote repos and a local clone).
- * It is a merge styles agnostic. It can detect common merge styles such as merge with a merge commit, rebase/ff merge and squash merge.
+ * It is merge styles agnostic. It can detect common merge styles such as merge with a merge commit, rebase/ff merge and squash merge.
  * It can also inspect remote branches so it deletes them from remotes for you in case you've forgotten to.
  * Moreover, it runs in parallel. Otherwise, large repos with hundreds of stale branches would've taken a couple of minutes to inspect whether they are merged.
 

--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -39,14 +39,6 @@ Comma separated multiple glob patterns (e.g. `release\-*`, `feature/*`) of branc
 Prevents too frequent updates. Seconds between updates in seconds. 0 to disable. [default: 5] [config: trim.updateInterval]
 
 .TP
-\fB\-s\fR, \fB\-\-scan\fR=\fIscan\fR
-Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local, remote`. `:<remote name>` is necessary to a `<scan range>` when the scan range implies `remote`. You can use `*` as `<remote name>` to scan branches from all remotes. [default : `local`] [config: trim.scan]
-
-When `local` is specified, scans tracking local branches, tracking its upstreams, and all non\-tracking local branches. When `remote:<remote name>` is specified, scans non\-upstream remote tracking branches from `<remote name>`. `all` implies `local,remote`.
-
-You might usually want to use one of these: `\-\-scan local` alone or `\-\-scan all:origin` with `\-\-delete merged:origin,remote:origin` option.
-
-.TP
 \fB\-d\fR, \fB\-\-delete\fR=\fIdelete\fR
 Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged, merged\-local, merged\-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged\-remote`, `diverged` or `remote`. You can use `*` as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
 

--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -40,11 +40,11 @@ Prevents too frequent updates. Seconds between updates in seconds. 0 to disable.
 
 .TP
 \fB\-d\fR, \fB\-\-delete\fR=\fIdelete\fR
-Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged, merged\-local, merged\-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged\-remote`, `diverged` or `remote`. You can use `*` as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
+Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged, merged\-local, merged\-remote, stray, diverged, local, remote`. `:<remote name>` is only necessary to a `<delete range>` when the range is applied to remote branches. You can use `*` as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
 
 `merged` implies `merged\-local,merged\-remote`.
 
-When `local` is specified, deletes non\-tracking merged local branches. When `remote` is specified, deletes non\-upstream merged remote tracking branches.
+`merged\-local` will delete merged tracking local branches. `merged\-remote:<remote>` will delete merged upstream branches from `<remote>`. `stray` will delete tracking local branches, which is not merged, but the upstream is gone. `diverged:<remote>` will delete merged tracking local branches, and their upstreams from `<remote>` even if the upstreams are not merged and diverged from local ones. `local` will delete non\-tracking merged local branches. `remote:<remote>` will delete non\-upstream merged remote tracking branches. Use with caution when you are using other than `merged`. It might lose changes, and even nuke repositories.
 .SH EXIT STATUS
 .TP
 \fB0\fR

--- a/docs/git-trim.1
+++ b/docs/git-trim.1
@@ -48,9 +48,9 @@ You might usually want to use one of these: `\-\-scan local` alone or `\-\-scan 
 
 .TP
 \fB\-d\fR, \fB\-\-delete\fR=\fIdelete\fR
-Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged, merged\-local, merged\-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged\-remote`, `diverged` or `remote`. You can use `*` as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
+Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged, merged\-local, merged\-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged\-remote`, `diverged` or `remote`. You can use `*` as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
 
-`all` implies `merged,stray,diverged,local,remote`. `merged` implies `merged\-local,merged\-remote`.
+`merged` implies `merged\-local,merged\-remote`.
 
 When `local` is specified, deletes non\-tracking merged local branches. When `remote` is specified, deletes non\-upstream merged remote tracking branches.
 .SH EXIT STATUS

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -43,15 +43,19 @@ OPTIONS
 
        -d, --delete=delete
               Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged,
-              merged-local, merged-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a
-              `<delete range>` when the delete range implies `merged-remote`, `diverged` or `remote`. You can use `*`
-              as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config:
-              trim.delete]
+              merged-local, merged-remote, stray, diverged, local, remote`. `:<remote name>` is only necessary to a
+              `<delete range>` when the range is applied to remote branches. You can use `*` as `<remote name>` to
+              delete a range of branches from all remotes. [default : `merged:origin`] [config: trim.delete]
 
               `merged` implies `merged-local,merged-remote`.
 
-              When `local` is specified, deletes non-tracking merged local branches. When `remote` is specified,
-              deletes non-upstream merged remote tracking branches.
+              `merged-local` will delete merged tracking local branches. `merged-remote:<remote>` will delete merged
+              upstream branches from `<remote>`. `stray` will delete tracking local branches, which is not merged,
+              but the upstream is gone. `diverged:<remote>` will delete merged tracking local branches, and their
+              upstreams from `<remote>` even if the upstreams are not merged and diverged from local ones. `local`
+              will delete non-tracking merged local branches. `remote:<remote>` will delete non-upstream merged
+              remote tracking branches. Use with caution when you are using other than `merged`. It might lose
+              changes, and even nuke repositories.
 
 EXIT STATUS
        0      Successful program execution.

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -55,13 +55,13 @@ OPTIONS
               merged:origin,remote:origin` option.
 
        -d, --delete=delete
-              Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `all, merged,
+              Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged,
               merged-local, merged-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a
               `<delete range>` when the delete range implies `merged-remote`, `diverged` or `remote`. You can use `*`
               as `<remote name>` to delete a range of branches from all remotes. [default : `merged:origin`] [config:
               trim.delete]
 
-              `all` implies `merged,stray,diverged,local,remote`. `merged` implies `merged-local,merged-remote`.
+              `merged` implies `merged-local,merged-remote`.
 
               When `local` is specified, deletes non-tracking merged local branches. When `remote` is specified,
               deletes non-upstream merged remote tracking branches.

--- a/docs/git-trim.man
+++ b/docs/git-trim.man
@@ -41,19 +41,6 @@ OPTIONS
               Prevents too frequent updates. Seconds between updates in seconds. 0 to disable. [default: 5] [config:
               trim.updateInterval]
 
-       -s, --scan=scan
-              Comma separated values of `<scan range>[:<remote name>]`. Scan range is one of the `all, local,
-              remote`. `:<remote name>` is necessary to a `<scan range>` when the scan range implies `remote`. You
-              can use `*` as `<remote name>` to scan branches from all remotes. [default : `local`] [config:
-              trim.scan]
-
-              When `local` is specified, scans tracking local branches, tracking its upstreams, and all non-tracking
-              local branches. When `remote:<remote name>` is specified, scans non-upstream remote tracking branches
-              from `<remote name>`. `all` implies `local,remote`.
-
-              You might usually want to use one of these: `--scan local` alone or `--scan all:origin` with `--delete
-              merged:origin,remote:origin` option.
-
        -d, --delete=delete
               Comma separated values of `<delete range>[:<remote name>]`. Delete range is one of the `merged,
               merged-local, merged-remote, stray, diverged, local, remote`. `:<remote name>` is necessary to a

--- a/src/args.rs
+++ b/src/args.rs
@@ -74,12 +74,11 @@ pub struct Args {
     pub scan: Vec<ScanRange>,
 
     /// Comma separated values of `<delete range>[:<remote name>]`.
-    /// Delete range is one of the `all, merged, merged-local, merged-remote, stray, diverged, local, remote`.
+    /// Delete range is one of the `merged, merged-local, merged-remote, stray, diverged, local, remote`.
     /// `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged-remote`, `diverged` or `remote`.
     /// You can use `*` as `<remote name>` to delete a range of branches from all remotes.
     /// [default : `merged:origin`] [config: trim.delete]
     ///
-    /// `all` implies `merged,stray,diverged,local,remote`.
     /// `merged` implies `merged-local,merged-remote`.
     ///
     /// When `local` is specified, deletes non-tracking merged local branches.
@@ -165,7 +164,6 @@ pub struct ScopeParseError {
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]
 pub enum DeleteRange {
-    All(Scope),
     Merged(Scope),
     MergedLocal,
     MergedRemote(Scope),
@@ -191,7 +189,6 @@ impl FromStr for DeleteRange {
     fn from_str(arg: &str) -> Result<DeleteRange, Self::Err> {
         let some_pair: Vec<_> = arg.splitn(2, ':').map(str::trim).collect();
         match *some_pair.as_slice() {
-            ["all", remote] => Ok(DeleteRange::All(remote.parse()?)),
             ["merged", remote] => Ok(DeleteRange::Merged(remote.parse()?)),
             ["stray"] => Ok(DeleteRange::Stray),
             ["diverged", remote] => Ok(DeleteRange::Diverged(remote.parse()?)),
@@ -207,12 +204,6 @@ impl FromStr for DeleteRange {
 impl DeleteRange {
     fn to_delete_units(&self) -> Vec<DeleteUnit> {
         match self {
-            DeleteRange::All(scope) => vec![
-                DeleteUnit::MergedLocal,
-                DeleteUnit::MergedRemote(scope.clone()),
-                DeleteUnit::Stray,
-                DeleteUnit::Diverged(scope.clone()),
-            ],
             DeleteRange::Merged(scope) => vec![
                 DeleteUnit::MergedLocal,
                 DeleteUnit::MergedRemote(scope.clone()),

--- a/src/args.rs
+++ b/src/args.rs
@@ -61,14 +61,19 @@ pub struct Args {
 
     /// Comma separated values of `<delete range>[:<remote name>]`.
     /// Delete range is one of the `merged, merged-local, merged-remote, stray, diverged, local, remote`.
-    /// `:<remote name>` is necessary to a `<delete range>` when the delete range implies `merged-remote`, `diverged` or `remote`.
+    /// `:<remote name>` is only necessary to a `<delete range>` when the range is applied to remote branches.
     /// You can use `*` as `<remote name>` to delete a range of branches from all remotes.
     /// [default : `merged:origin`] [config: trim.delete]
     ///
     /// `merged` implies `merged-local,merged-remote`.
     ///
-    /// When `local` is specified, deletes non-tracking merged local branches.
-    /// When `remote` is specified, deletes non-upstream merged remote tracking branches.
+    /// `merged-local` will delete merged tracking local branches.
+    /// `merged-remote:<remote>` will delete merged upstream branches from `<remote>`.
+    /// `stray` will delete tracking local branches, which is not merged, but the upstream is gone.
+    /// `diverged:<remote>` will delete merged tracking local branches, and their upstreams from `<remote>` even if the upstreams are not merged and diverged from local ones.
+    /// `local` will delete non-tracking merged local branches.
+    /// `remote:<remote>` will delete non-upstream merged remote tracking branches.
+    /// Use with caution when you are using other than `merged`. It might lose changes, and even nuke repositories.
     #[clap(short, long, value_delimiter = ",")]
     pub delete: Vec<DeleteRange>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use git2::{BranchType, Config as GitConfig, Error, ErrorClass, ErrorCode, Remote, Repository};
 use log::*;
 
-use crate::args::{Args, DeleteFilter, DeleteRange, ScanFilter, ScanRange};
+use crate::args::{Args, DeleteFilter, DeleteRange};
 use crate::branch::{LocalBranch, RemoteTrackingBranchStatus};
 use std::collections::HashSet;
 
@@ -22,7 +22,6 @@ pub struct Config {
     pub update_interval: ConfigValue<u64>,
     pub confirm: ConfigValue<bool>,
     pub detach: ConfigValue<bool>,
-    pub scan: ConfigValue<ScanFilter>,
     pub delete: ConfigValue<DeleteFilter>,
 }
 
@@ -63,10 +62,6 @@ impl Config {
             .with_default(true)
             .read()?
             .expect("has default");
-        let scan = get_comma_separated_multi(config, "trim.scan")
-            .with_explicit("cli", non_empty(args.scan.clone()))
-            .with_default(ScanRange::local())
-            .parses_and_collect::<ScanFilter>()?;
         let delete = get_comma_separated_multi(config, "trim.delete")
             .with_explicit("cli", non_empty(args.delete.clone()))
             .with_default(DeleteRange::merged_origin())
@@ -79,7 +74,6 @@ impl Config {
             update_interval,
             confirm,
             detach,
-            scan,
             delete,
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ fn main(args: Args) -> Result<()> {
         &PlanParam {
             bases: config.bases.iter().map(String::as_str).collect(),
             protected_patterns: config.protected.iter().map(String::as_str).collect(),
-            scan: config.scan.clone(),
             delete: config.delete.clone(),
             detach: *config.detach,
         },

--- a/tests/filter_accidential_track.rs
+++ b/tests/filter_accidential_track.rs
@@ -89,10 +89,6 @@ fn test_default_config_tries_to_delete_accidential_track() -> Result<()> {
             delete: DeleteFilter::from_iter(vec![
                 DeleteRange::MergedLocal,
                 DeleteRange::MergedRemote(Scope::All),
-                DeleteRange::Stray,
-                DeleteRange::Diverged(Scope::All),
-                DeleteRange::Local,
-                DeleteRange::Remote(Scope::All),
             ]),
             ..param()
         },

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -8,7 +8,7 @@ use std::thread::spawn;
 use log::*;
 use tempfile::{tempdir, TempDir};
 
-use git_trim::args::{DeleteFilter, DeleteRange, ScanFilter, ScanRange, Scope};
+use git_trim::args::{DeleteFilter, DeleteRange, Scope};
 use git_trim::PlanParam;
 
 #[derive(Default)]
@@ -205,14 +205,11 @@ pub fn test_default_param() -> PlanParam<'static> {
     PlanParam {
         bases: vec!["master"],
         protected_patterns: Vec::new(),
-        scan: ScanFilter::from_iter(vec![ScanRange::Local]),
         delete: DeleteFilter::from_iter(vec![
             MergedLocal,
             MergedRemote(Scope::All),
             Stray,
             Diverged(Scope::All),
-            Local,
-            Remote(Scope::All),
         ]),
         detach: true,
     }

--- a/tests/non_trackings_non_upstreams.rs
+++ b/tests/non_trackings_non_upstreams.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 use anyhow::Result;
 use git2::Repository;
 
-use git_trim::args::{ScanFilter, ScanRange, Scope};
+use git_trim::args::{DeleteFilter, DeleteRange, Scope};
 use git_trim::{
     get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
 };
@@ -45,7 +45,14 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        scan: ScanFilter::from_iter(vec![ScanRange::All(Scope::All)]),
+        delete: DeleteFilter::from_iter(vec![
+            DeleteRange::MergedLocal,
+            DeleteRange::MergedRemote(Scope::Scoped("origin".to_owned())),
+            DeleteRange::Stray,
+            DeleteRange::Diverged(Scope::Scoped("origin".to_owned())),
+            DeleteRange::Local,
+            DeleteRange::Remote(Scope::Scoped("origin".to_owned())),
+        ]),
         ..test_default_param()
     }
 }


### PR DESCRIPTION
issue: https://github.com/foriequal0/git-trim/issues/137#issuecomment-686278710

**Breaking Change**
This removes `--scan` option. Also it doesn't scan non-tracking local branches by default.
It'll determine which branches are scanned based on what is passed to `--delete` flag.
Also I've removed `all` option from `--delete` which can cause confusions.