### PR TITLE
Provide porcelain output for scripts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,8 @@ dependencies = [
  "rayon",
  "regex",
  "rson_rs",
+ "serde",
+ "serde_json",
  "tempfile",
  "textwrap 0.12.1",
  "thiserror",
@@ -326,6 +328,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jobserver"
@@ -679,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +703,31 @@ name = "serde"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "strsim"
@@ -743,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
 dependencies = [
  "libc",
  "winapi",
@@ -845,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ textwrap = { version = "0.12.1", features = ["terminal_size"] }
 man = { version = "0.3.0", optional = true }
 rson_rs = { version = "0.2.1", optional = true }
 regex = { version = "1.4.2", optional = true }
+serde =  { version = "1.0.117", features = ["derive"] }
+serde_json = "1.0.59"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -40,6 +40,10 @@ pub struct Args {
     #[clap(long, hidden(true))]
     pub update: bool,
 
+    /// Output for scripting. Options are "json" for full structured output or "local" or "remote" for a list of branches to be deleted.
+    #[clap(long)]
+    pub porcelain: Option<PorcelainFormat>,
+
     /// Prevents too frequent updates. Seconds between updates in seconds. 0 to disable.
     /// [default: 5] [config: trim.updateInterval]
     #[clap(long)]
@@ -125,6 +129,41 @@ fn exclusive_bool(
     } else {
         None
     }
+}
+
+/// Configuration of --porcelain format.
+#[derive(Debug)]
+pub enum PorcelainFormat {
+    /// List of to-be-deleted local branches
+    LocalBranches,
+    /// List of remote branches to be deleted.
+    RemoteBranches,
+    /// Full structured JSON output
+    JSON,
+}
+
+impl FromStr for PorcelainFormat {
+    type Err = PorcelainFormatParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim() {
+            "" => Err(PorcelainFormatParseError {
+                message: "Porcelain format is empty".to_owned(),
+            }),
+            "json" => Ok(PorcelainFormat::JSON),
+            "local" | "l" => Ok(PorcelainFormat::LocalBranches),
+            "remote" | "r" => Ok(PorcelainFormat::RemoteBranches),
+            unknown => Err(PorcelainFormatParseError {
+                message: format!("Unknown porcelain format: {}", unknown),
+            }),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("{message}")]
+pub struct PorcelainFormatParseError {
+    message: String,
 }
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use anyhow::{Context, Result};
 use git2::{Branch, Config, Direction, Reference, Repository};
 use log::*;
+use serde::Serialize;
 use thiserror::Error;
 
 use crate::config;
@@ -12,7 +13,7 @@ pub trait Refname {
     fn refname(&self) -> &str;
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Clone, Serialize)]
 pub struct LocalBranch {
     pub refname: String,
 }
@@ -83,7 +84,7 @@ impl<'repo> TryFrom<&git2::Reference<'repo>> for LocalBranch {
     }
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Clone)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Clone, Serialize)]
 pub struct RemoteTrackingBranch {
     pub refname: String,
 }
@@ -181,7 +182,7 @@ pub enum RemoteTrackingBranchStatus {
     None,
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Debug, Serialize)]
 pub struct RemoteBranch {
     pub remote: String,
     pub refname: String,

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,6 +7,7 @@ use crossbeam_channel::unbounded;
 use git2::{BranchType, Config, Repository};
 use log::*;
 use rayon::prelude::*;
+use serde::Serialize;
 
 use crate::args::DeleteFilter;
 use crate::branch::{
@@ -17,12 +18,14 @@ use crate::subprocess::{self, get_worktrees, RemoteHead};
 use crate::util::ForceSendSync;
 use crate::{config, BaseSpec, Git};
 
+#[derive(Serialize)]
 pub struct TrimPlan {
     pub skipped: HashMap<String, SkipSuggestion>,
     pub to_delete: HashSet<ClassifiedBranch>,
     pub preserved: Vec<Preserved>,
 }
 
+#[derive(Serialize)]
 pub struct Preserved {
     pub branch: ClassifiedBranch,
     pub reason: String,
@@ -390,7 +393,7 @@ impl TrimPlan {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Serialize)]
 pub enum SkipSuggestion {
     Tracking,
     TrackingRemote(String),
@@ -434,7 +437,7 @@ fn get_protect_pattern<'a, B: Refname>(
     Ok(None)
 }
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize)]
 pub enum ClassifiedBranch {
     MergedLocal(LocalBranch),
     Stray(LocalBranch),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod branch;
 pub mod config;
 mod core;
 mod merge_tracker;
+pub mod porcelain_outputs;
 mod simple_glob;
 mod subprocess;
 mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ use dialoguer::Confirm;
 use git2::{BranchType, Repository};
 use log::*;
 
-use git_trim::args::Args;
+use git_trim::args::{Args, PorcelainFormat};
 use git_trim::config::{self, get, Config, ConfigValue};
+use git_trim::porcelain_outputs::{print_json, print_local, print_remote};
 use git_trim::{
     delete_local_branches, delete_remote_branches, get_trim_plan, ls_remote_head, remote_update,
     ClassifiedBranch, ForceSendSync, Git, LocalBranch, PlanParam, RemoteHead, RemoteTrackingBranch,
@@ -58,7 +59,23 @@ fn main(args: Args) -> Result<()> {
         },
     )?;
 
-    print_summary(&plan, &git.repo)?;
+    match args.porcelain {
+        None => {
+            print_summary(&plan, &git.repo)?;
+        }
+        Some(PorcelainFormat::LocalBranches) => {
+            print_local(&plan, &git.repo, &mut std::io::stdout())?;
+            return Ok(());
+        }
+        Some(PorcelainFormat::RemoteBranches) => {
+            print_remote(&plan, &git.repo, &mut std::io::stdout())?;
+            return Ok(());
+        }
+        Some(PorcelainFormat::JSON) => {
+            print_json(&plan, &git.repo, &mut std::io::stdout())?;
+            return Ok(());
+        }
+    }
 
     let locals = plan.locals_to_delete();
     let remotes = plan.remotes_to_delete(&git.repo)?;

--- a/src/porcelain_outputs.rs
+++ b/src/porcelain_outputs.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use git2::Repository;
+
+use crate::TrimPlan;
+
+/// Prints all locally to-be-deleted branches.
+pub fn print_local(
+    plan: &TrimPlan,
+    _repo: &Repository,
+    mut writer: impl std::io::Write,
+) -> Result<()> {
+    let mut merged_locals = Vec::new();
+    for branch in &plan.to_delete {
+        if let Some(local) = branch.local() {
+            merged_locals.push(local.short_name().to_owned());
+        }
+    }
+
+    merged_locals.sort();
+    for branch in merged_locals {
+        writeln!(writer, "{}", branch)?;
+    }
+
+    Ok(())
+}
+
+/// Print all remotely to-be-deleted branches in the form "<remote>/<branch_name>"
+pub fn print_remote(
+    plan: &TrimPlan,
+    repo: &Repository,
+    mut writer: impl std::io::Write,
+) -> Result<()> {
+    let mut merged_remotes = Vec::new();
+    for branch in &plan.to_delete {
+        if let Some(remote) = branch.remote(repo)? {
+            merged_remotes.push(remote);
+        }
+    }
+
+    merged_remotes.sort();
+    for branch in merged_remotes {
+        let branch_name = &branch.refname["/refs/heads".len()..];
+        writeln!(writer, "{}/{}", branch.remote, branch_name)?;
+    }
+
+    Ok(())
+}
+
+pub fn print_json(plan: &TrimPlan, _repo: &Repository, writer: impl std::io::Write) -> Result<()> {
+    serde_json::to_writer(writer, &plan)?;
+
+    Ok(())
+}

--- a/tests/filter_accidential_track_porcelain.rs
+++ b/tests/filter_accidential_track_porcelain.rs
@@ -1,0 +1,155 @@
+mod fixture;
+
+use std::convert::TryFrom;
+use std::iter::FromIterator;
+
+use anyhow::Result;
+use git2::Repository;
+
+use git_trim::args::{DeleteFilter, DeleteRange, Scope};
+use git_trim::{
+    get_trim_plan, ClassifiedBranch, Git, LocalBranch, PlanParam, RemoteTrackingBranch,
+};
+
+use git_trim::porcelain_outputs::*;
+
+use fixture::{rc, test_default_param, Fixture};
+
+fn fixture() -> Fixture {
+    rc().append_fixture_trace(
+        r#"
+        git init origin --bare
+
+        git clone origin local
+        local <<EOF
+            git config user.name "Local Test"
+            git config user.email "local@test"
+            git config remote.pushdefault origin
+            git config push.default simple
+
+            echo "Hello World!" > README.md
+            git add README.md
+            git commit -m "Initial commit"
+            git push -u origin master
+        EOF
+
+        git clone origin contributer
+        within contributer <<EOF
+            git config user.name "Contributer Test"
+            git config user.email "contributer@test"
+            git config remote.pushdefault origin
+            git config push.default simple
+        EOF
+
+        within contributer <<EOF
+            git checkout -b feature
+            touch awesome-patch
+            git add awesome-patch
+            git commit -m "Awesome patch"
+            touch another-patch
+            git add another-patch
+            git commit -m "Another patch"
+        EOF
+
+        local <<EOF
+            git remote add contributer ../contributer
+            git remote update
+        EOF
+        "#,
+    )
+}
+
+fn param() -> PlanParam<'static> {
+    PlanParam {
+        delete: DeleteFilter::from_iter(vec![
+            DeleteRange::MergedLocal,
+            DeleteRange::MergedRemote(Scope::Scoped("origin".to_string())),
+        ]),
+        ..test_default_param()
+    }
+}
+
+#[test]
+fn test_default_config_tries_to_delete_accidential_track() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        local <<EOF
+            git checkout --track contributer/feature
+
+            git checkout master
+            git merge feature --no-ff
+            git push -u origin master
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let plan = get_trim_plan(
+        &git,
+        &PlanParam {
+            delete: DeleteFilter::from_iter(vec![
+                DeleteRange::MergedLocal,
+                DeleteRange::MergedRemote(Scope::All),
+            ]),
+            ..param()
+        },
+    )?;
+    assert_eq!(
+        plan.to_delete,
+        set! {
+            ClassifiedBranch::MergedLocal(LocalBranch::new("refs/heads/feature")),
+            ClassifiedBranch::MergedRemoteTracking(
+                RemoteTrackingBranch::new("refs/remotes/contributer/feature")),
+        },
+    );
+
+    let mut result = Vec::new();
+    print_local(&plan, &git.repo, &mut result).unwrap();
+    let result = std::str::from_utf8(&result)?;
+    assert_eq!(result, "feature\n");
+
+    let mut result = Vec::new();
+    print_remote(&plan, &git.repo, &mut result).unwrap();
+    let result = std::str::from_utf8(&result)?;
+    assert_eq!(result, "contributer/feature\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_accidential_track() -> Result<()> {
+    let guard = fixture().prepare(
+        "local",
+        r#"
+        local <<EOF
+            git checkout --track contributer/feature
+
+            git checkout master
+            git merge feature --no-ff
+            git push -u origin master
+        EOF
+        "#,
+    )?;
+
+    let git = Git::try_from(Repository::open(guard.working_directory())?)?;
+    let plan = get_trim_plan(&git, &param())?;
+    assert_eq!(
+        plan.to_delete,
+        set! {
+            ClassifiedBranch::MergedLocal(LocalBranch::new("refs/heads/feature")),
+        },
+    );
+
+    let mut result = Vec::new();
+    print_local(&plan, &git.repo, &mut result).unwrap();
+    let result = std::str::from_utf8(&result)?;
+    assert_eq!(result, "feature\n");
+
+    let mut result = Vec::new();
+    print_remote(&plan, &git.repo, &mut result).unwrap();
+    let result = std::str::from_utf8(&result)?;
+    assert_eq!(result, "");
+
+    Ok(())
+}


### PR DESCRIPTION
This provides an option `--porcelain=(local|remote|json)`

Options:
* local branches
* remote branches
* JSON output.

The first two options print the to-be-deleted branches (either local or remote). This can be piped into further
scripts. The second output provides all available information in the form of JSON output. This can then be filtered with *gron* or *jq*, or *nushell*.

\#138
