### PR TITLE
Mention in README that can install using homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ git-trim
 ### Installation
 Download binary from [Releases](https://github.com/foriequal0/git-trim/releases), and put it under your `PATH` directories.
 
-You can also install with `cargo install git-trim` if you have `cargo`.
+You can also install with `cargo install git-trim` if you have `cargo`. 
+
+You can also install with `brew install git-trim` if you have [`homebrew`](https://brew.sh) on OSX or Linux.
 
 It uses [`git2`](https://crates.io/crates/git2) under the hood which depends conditionally on [`openssl-sys`](https://crates.io/crates/openssl) on *nix platform.
 You might need to install `libssl-dev` and `pkg-config` packages if you build from the source. See: https://docs.rs/openssl/0.10.28/openssl/#automatic


### PR DESCRIPTION
I note that you can install git-trim using [homebrew](https://brew.sh) on OSX and Linux but that isn't mentioned in the README. 

If you would like it mentioned, then this pull request will make it so.

If you don't want it mentioned, no worries! 