### PR TITLE
Close the ` in the suggestion message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,18 +250,18 @@ pub fn print_summary(plan: &TrimPlan, repo: &Repository) -> Result<()> {
         };
         if let [single] = tracking_remotes.as_slice() {
             println!(
-                "    *{}: Add `--delete 'merged:{}' flag.",
+                "    *{}: Add `--delete 'merged:{}'` flag.",
                 SkipSuggestion::KIND_TRACKING,
                 single
             );
         } else if tracking_remotes.len() > 1 {
             println!(
-                "    *{}: Add `--delete 'merged:*' flag.",
+                "    *{}: Add `--delete 'merged:*'` flag.",
                 SkipSuggestion::KIND_TRACKING,
             );
         } else if tracking {
             println!(
-                "    *{}: Add `--delete 'merged-local' flag.",
+                "    *{}: Add `--delete 'merged-local'` flag.",
                 SkipSuggestion::KIND_TRACKING,
             );
         }
@@ -271,7 +271,7 @@ pub fn print_summary(plan: &TrimPlan, repo: &Repository) -> Result<()> {
             .any(|suggest| suggest == &SkipSuggestion::NonTracking);
         if non_tracking {
             println!(
-                "    *{}: Set an upstream to make it a tracking branch or add `--delete 'local' flag.",
+                "    *{}: Set an upstream to make it a tracking branch or add `--delete 'local'` flag.",
                 SkipSuggestion::KIND_NON_TRACKING,
             );
         }
@@ -287,13 +287,13 @@ pub fn print_summary(plan: &TrimPlan, repo: &Repository) -> Result<()> {
         };
         if let [single] = non_upstream_remotes.as_slice() {
             println!(
-                "    *{}: Make it upstream of a tracking branch or add `--delete 'remote:{}' flag.",
+                "    *{}: Make it upstream of a tracking branch or add `--delete 'remote:{}'` flag.",
                 SkipSuggestion::KIND_NON_UPSTREAM,
                 single
             );
         } else if non_upstream_remotes.len() > 1 {
             println!(
-                "    *{}: Make it upstream of a tracking branch or add `--delete 'remote:*' flag.",
+                "    *{}: Make it upstream of a tracking branch or add `--delete 'remote:*'` flag.",
                 SkipSuggestion::KIND_NON_UPSTREAM,
             );
         }


### PR DESCRIPTION
This PR fixes #181 

Here is the same fixed output:

```sh
Branches that will remain:
  local branches:
    master [stray, but: base]
    x *2
  remote references:
    jh/f/working *3
    jh/master *3
    origin/all-your-bases *3
    origin/master [base]
  Some branches are skipped. Consider following to scan them:
    *2: Set an upstream to make it a tracking branch or add `--delete 'local'` flag.
    *3: Make it upstream of a tracking branch or add `--delete 'remote:*'` flag.
```

As you can see, git-trim prints closing `` ` `` in `` `--delete 'local'` ``.