### PR TITLE
Switch default branch name from `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You might need to install `libssl-dev` and `pkg-config` packages if you build fr
 
 #### Are you using git-flow?
 
-Don't forget to `git config trim.bases develop,master`.
+Don't forget to `git config trim.bases develop,main`.
 
 ## Why have you made this? Show me how it works.
 
@@ -46,7 +46,7 @@ After some working with the repository, you'll execute `git fetch --prune` or `g
 However, you'll likely see the mess of local branches whose upstreams are already merged and deleted on the remote.
 Because `git fetch --prune` only deletes remote-tracking branches (or remote references, `refs/remotes/<remote>/<branch>`) but not local tracking branches (`refs/heads/<branch>`) for you.
 It is worse if remote branches that are merged but the maintainer forgot to delete them,
-the remote-tracking branches would not be deleted and so on even if you know that it is merged into the master.
+the remote-tracking branches would not be deleted and so on even if you know that it is merged into the main.
 
 ![before](images/0-before.png)
 
@@ -111,7 +111,7 @@ Not because `--force` is dangerous. Just `gone` doesn't mean it is fully merged 
 
  * It inspects the upstream of tracking branches whether they are 'fully' merged, not just whether they are gone.
  I've spent about half of the code on scenario tests. I wanted to make sure that it doesn't delete unmerged contents accidentally in any case.
- * It supports github flow (master-feature tiered branch strategy), git flow (master-develop-feature tiered branch strategy),
+ * It supports github flow (main-feature tiered branch strategy), git flow (main-develop-feature tiered branch strategy),
  and simple workflow (with a remote repo and a local clone), and triangular workflow (with two remote repos and a local clone).
  * It is merge styles agnostic. It can detect common merge styles such as merge with a merge commit, rebase/ff merge and squash merge.
  * It can also inspect remote branches so it deletes them from remotes for you in case you've forgotten to.
@@ -136,12 +136,12 @@ The term is borrowed from the git's remote tracking states.
 
 ### I'm even more lazy to type `git trim`
 
-Try this `post-merge` hook. It automatically calls `git trim --no-update` everytime you `git pull` on `master` or `develop`. `git config fetch.prune true` is recommended with this hook.
+Try this `post-merge` hook. It automatically calls `git trim --no-update` everytime you `git pull` on `main` or `develop`. `git config fetch.prune true` is recommended with this hook.
 ```shell
 #!/bin/bash
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 case "$HEAD_BRANCH" in
-    "master"|"develop") ;;
+    "main"|"develop") ;;
     *) exit ;;
 esac
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,9 +104,9 @@ fn error_no_bases(repo: &Repository, bases: &ConfigValue<HashSet<String>>) -> Re
         }
     }
     const GENERAL_HELP: &[&str] = &[
-        "`git config trim.bases develop,master` for a repository.",
-        "`git config --global trim.bases develop,master` to set globally.",
-        "`git trim --bases develop,master` to set temporarily.",
+        "`git config trim.bases develop,main` for a repository.",
+        "`git config --global trim.bases develop,main` to set globally.",
+        "`git trim --bases develop,main` to set temporarily.",
     ];
     match bases {
         ConfigValue::Explicit(_) => {

--- a/src/remote_head_change_checker.rs
+++ b/src/remote_head_change_checker.rs
@@ -96,9 +96,9 @@ impl RemoteHeadChangeChecker {
         }
         eprintln!(
             r#"Or you can set base branches manually:
- * `git config trim.bases develop,master` will set base branches for git-trim for a repository.
- * `git config --global trim.bases develop,master` will set base branches for `git-trim` globally.
- * `git trim --bases develop,master` will temporarily set base branches for `git-trim`"#
+ * `git config trim.bases develop,main` will set base branches for git-trim for a repository.
+ * `git config --global trim.bases develop,main` will set base branches for `git-trim` globally.
+ * `git trim --bases develop,main` will temporarily set base branches for `git-trim`"#
         );
 
         Ok(())

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -45,7 +45,7 @@ fn test_bases_implicit_value() -> Result<()> {
 
     assert_eq!(
         config.bases,
-        ConfigValue::Implicit(HashSet::from_iter(vec!["master".to_owned()]))
+        ConfigValue::Implicit(HashSet::from_iter(vec!["main".to_owned()]))
     );
     Ok(())
 }

--- a/tests/filter_accidential_track.rs
+++ b/tests/filter_accidential_track.rs
@@ -28,7 +28,7 @@ fn fixture() -> Fixture {
             echo "Hello World!" > README.md
             git add README.md
             git commit -m "Initial commit"
-            git push -u origin master
+            git push -u origin main
         EOF
 
         git clone origin contributer
@@ -75,9 +75,9 @@ fn test_default_config_tries_to_delete_accidential_track() -> Result<()> {
         local <<EOF
             git checkout --track contributer/feature
 
-            git checkout master
+            git checkout main
             git merge feature --no-ff
-            git push -u origin master
+            git push -u origin main
         EOF
         "#,
     )?;
@@ -112,9 +112,9 @@ fn test_accidential_track() -> Result<()> {
         local <<EOF
             git checkout --track contributer/feature
 
-            git checkout master
+            git checkout main
             git merge feature --no-ff
-            git push -u origin master
+            git push -u origin main
         EOF
         "#,
     )?;

--- a/tests/fixture/mod.rs
+++ b/tests/fixture/mod.rs
@@ -203,7 +203,7 @@ macro_rules! set {
 pub fn test_default_param() -> PlanParam<'static> {
     use DeleteRange::*;
     PlanParam {
-        bases: vec!["master"],
+        bases: vec!["main"],
         protected_patterns: Vec::new(),
         delete: DeleteFilter::from_iter(vec![
             MergedLocal,

--- a/tests/hub_cli_checkout.rs
+++ b/tests/hub_cli_checkout.rs
@@ -34,7 +34,7 @@ fn fixture() -> Fixture {
             git config push.default simple
             git remote add upstream ../upstream
             git fetch upstream
-            git branch -u upstream/master master
+            git branch -u upstream/main main
         EOF
         origin <<EOF
             git checkout -b feature
@@ -81,7 +81,7 @@ fn test_accepted() -> Result<()> {
         EOF
         # clicked delete branch button
         origin <<EOF
-            git checkout master
+            git checkout main
             git branch -D feature
         EOF
         "#,
@@ -152,7 +152,7 @@ fn test_modified_and_accepted() -> Result<()> {
         EOF
         # click delete button
         origin <<EOF
-            git checkout master
+            git checkout main
             git branch -D feature
         EOF
         "#,
@@ -220,7 +220,7 @@ fn test_rejected() -> Result<()> {
         EOF
         # clicked delete branch button
         origin <<EOF
-            git checkout master
+            git checkout main
             git branch -D feature
         EOF
         "#,

--- a/tests/merge_styles.rs
+++ b/tests/merge_styles.rs
@@ -48,7 +48,7 @@ fn test_noff() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature --no-ff
             git branch -D feature
         EOF
@@ -73,8 +73,8 @@ fn test_rebase() -> Result<()> {
         r#"
         origin <<EOF
             git checkout -b rebase-tmp feature
-            git rebase master
-            git checkout master
+            git rebase main
+            git checkout main
             git merge rebase-tmp --ff-only
             git branch -D rebase-tmp feature
         EOF
@@ -98,7 +98,7 @@ fn test_squash() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature --squash && git commit --no-edit
             git branch -D feature
         EOF
@@ -149,9 +149,9 @@ fn test_mixed() -> Result<()> {
             git push -u origin "$NAME"
         }
         local <<EOF
-            mk_test_branches master rebaseme 3
-            mk_test_branches master squashme 3
-            mk_test_branches master noffme 3
+            mk_test_branches main rebaseme 3
+            mk_test_branches main squashme 3
+            mk_test_branches main noffme 3
         EOF
         "#,
     );
@@ -160,19 +160,19 @@ fn test_mixed() -> Result<()> {
         r#"
         origin <<EOF
             # squash
-            git checkout master
+            git checkout main
             git merge squashme --squash && git commit --no-edit
             git branch -D squashme
 
             # rebaseme
             git checkout -b rebase-tmp rebaseme
-            git rebase master
-            git checkout master
+            git rebase main
+            git checkout main
             git merge rebase-tmp --ff-only
             git branch -D rebase-tmp rebaseme
 
             # noff
-            git checkout master
+            git checkout main
             git merge noffme --no-ff
             git branch -D noffme
         EOF

--- a/tests/non_trackings_non_upstreams.rs
+++ b/tests/non_trackings_non_upstreams.rs
@@ -63,7 +63,7 @@ fn test_merged_non_tracking() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature
             git branch -d feature
         EOF
@@ -90,10 +90,10 @@ fn test_merged_non_upstream() -> Result<()> {
             git config core.bare true
         EOF
         local <<EOF
-            git checkout master
+            git checkout main
             git merge feature
             git branch -D feature
-            git push origin master
+            git push origin main
         EOF
         "#,
     )?;

--- a/tests/simple_git_flow.rs
+++ b/tests/simple_git_flow.rs
@@ -22,7 +22,7 @@ fn fixture() -> Fixture {
             git add README.md
             git commit -m "Initial commit"
 
-            git branch develop master
+            git branch develop main
         EOF
         git clone origin local
         local <<EOF
@@ -39,7 +39,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["develop", "master"], // Need to set bases manually for git flow
+        bases: vec!["develop", "main"], // Need to set bases manually for git flow
         ..test_default_param()
     }
 }
@@ -111,7 +111,7 @@ fn test_feature_to_develop_but_forgot_to_delete() -> Result<()> {
 }
 
 #[test]
-fn test_develop_to_master() -> Result<()> {
+fn test_develop_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
@@ -128,7 +128,7 @@ fn test_develop_to_master() -> Result<()> {
             git merge feature
             git branch -d feature
 
-            git checkout master
+            git checkout main
             git merge develop
         EOF
         "#,
@@ -147,7 +147,7 @@ fn test_develop_to_master() -> Result<()> {
 }
 
 #[test]
-fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
+fn test_develop_to_main_but_forgot_to_delete() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
@@ -163,7 +163,7 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
             git checkout develop
             git merge feature
 
-            git checkout master
+            git checkout main
             git merge develop
         EOF
         "#,
@@ -183,13 +183,13 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
 }
 
 #[test]
-fn test_hotfix_to_master() -> Result<()> {
+fn test_hotfix_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
         # prepare awesome patch
         local <<EOF
-            git checkout master
+            git checkout main
             git checkout -b hotfix
             touch hotfix
             git add hotfix
@@ -198,7 +198,7 @@ fn test_hotfix_to_master() -> Result<()> {
         EOF
 
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge hotfix
             git branch -D hotfix
         EOF
@@ -218,13 +218,13 @@ fn test_hotfix_to_master() -> Result<()> {
 }
 
 #[test]
-fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
+fn test_hotfix_to_main_forgot_to_delete() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
         # prepare awesome patch
         local <<EOF
-            git checkout master
+            git checkout main
             git checkout -b hotfix
             touch hotfix
             git add hotfix
@@ -233,7 +233,7 @@ fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
         EOF
 
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge hotfix
         EOF
         "#,
@@ -284,13 +284,13 @@ fn test_rejected_feature_to_develop() -> Result<()> {
 }
 
 #[test]
-fn test_rejected_hotfix_to_master() -> Result<()> {
+fn test_rejected_hotfix_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
         # prepare awesome patch
         local <<EOF
-            git checkout master
+            git checkout main
             git checkout -b hotfix
             touch hotfix
             git add hotfix
@@ -351,7 +351,7 @@ fn test_protected_feature_to_develop() -> Result<()> {
 }
 
 #[test]
-fn test_protected_feature_to_master() -> Result<()> {
+fn test_protected_feature_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
@@ -368,8 +368,8 @@ fn test_protected_feature_to_master() -> Result<()> {
             git merge feature
             git branch -d feature
 
-            git checkout master
-            git merge master
+            git checkout main
+            git merge main
         EOF
         "#,
     )?;
@@ -434,7 +434,7 @@ fn test_protected_branch_shouldnt_be_stray() -> Result<()> {
     let plan = get_trim_plan(
         &git,
         &PlanParam {
-            protected_patterns: vec!["refs/heads/master", "refs/heads/develop"],
+            protected_patterns: vec!["refs/heads/main", "refs/heads/develop"],
             ..param()
         },
     )?;

--- a/tests/simple_github_flow.rs
+++ b/tests/simple_github_flow.rs
@@ -45,7 +45,7 @@ fn test_accepted() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature
             git branch -d feature
         EOF
@@ -69,7 +69,7 @@ fn test_accepted_but_edited() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature
             git branch -d feature
         EOF
@@ -97,7 +97,7 @@ fn test_accepted_but_forgot_to_delete() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature
         EOF
         "#,
@@ -120,7 +120,7 @@ fn test_accepted_but_forgot_to_delete_and_edited() -> Result<()> {
         "local",
         r#"
         origin <<EOF
-            git checkout master
+            git checkout main
             git merge feature
         EOF
         local <<EOF

--- a/tests/triangular_git_flow.rs
+++ b/tests/triangular_git_flow.rs
@@ -21,7 +21,7 @@ fn fixture() -> Fixture {
             echo "Hello World!" > README.md
             git add README.md
             git commit -m "Initial commit"
-            git branch develop master
+            git branch develop main
         EOF
         git clone upstream origin -o upstream
         origin <<EOF
@@ -38,7 +38,7 @@ fn fixture() -> Fixture {
             git config push.default simple
             git remote add upstream ../upstream
             git fetch upstream
-            git branch -u upstream/master master
+            git branch -u upstream/main main
             git branch develop upstream/develop
             git branch -u upstream/develop develop
 
@@ -50,7 +50,7 @@ fn fixture() -> Fixture {
 
 fn param() -> PlanParam<'static> {
     PlanParam {
-        bases: vec!["develop", "master"], // Need to set bases manually for git flow
+        bases: vec!["develop", "main"], // Need to set bases manually for git flow
         ..test_default_param()
     }
 }
@@ -136,7 +136,7 @@ fn test_feature_to_develop_but_forgot_to_delete() -> Result<()> {
 }
 
 #[test]
-fn test_develop_to_master() -> Result<()> {
+fn test_develop_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
@@ -157,7 +157,7 @@ fn test_develop_to_master() -> Result<()> {
             git checkout develop
             git merge refs/pull/1/head
 
-            git checkout master
+            git checkout main
             git merge develop
         EOF
 
@@ -181,7 +181,7 @@ fn test_develop_to_master() -> Result<()> {
 }
 
 #[test]
-fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
+fn test_develop_to_main_but_forgot_to_delete() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
@@ -202,7 +202,7 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
             git checkout develop
             git merge refs/pull/1/head
 
-            git checkout master
+            git checkout main
             git merge develop
         EOF
         "#,
@@ -222,13 +222,13 @@ fn test_develop_to_master_but_forgot_to_delete() -> Result<()> {
 }
 
 #[test]
-fn test_hotfix_to_master() -> Result<()> {
+fn test_hotfix_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
         # prepare awesome patch
         local <<EOF
-            git checkout master
+            git checkout main
             git checkout -b hotfix
             touch hotfix
             git add hotfix
@@ -242,7 +242,7 @@ fn test_hotfix_to_master() -> Result<()> {
         EOF
 
         upstream <<EOF
-            git checkout master
+            git checkout main
             git merge refs/pull/1/head
         EOF
 
@@ -266,13 +266,13 @@ fn test_hotfix_to_master() -> Result<()> {
 }
 
 #[test]
-fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
+fn test_hotfix_to_main_forgot_to_delete() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
         # prepare awesome patch
         local <<EOF
-            git checkout master
+            git checkout main
             git checkout -b hotfix
             touch hotfix
             git add hotfix
@@ -286,7 +286,7 @@ fn test_hotfix_to_master_forgot_to_delete() -> Result<()> {
         EOF
 
         upstream <<EOF
-            git checkout master
+            git checkout main
             git merge refs/pull/1/head
         EOF
         "#,
@@ -343,13 +343,13 @@ fn test_rejected_feature_to_develop() -> Result<()> {
 }
 
 #[test]
-fn test_rejected_hotfix_to_master() -> Result<()> {
+fn test_rejected_hotfix_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
         # prepare awesome patch
         local <<EOF
-            git checkout master
+            git checkout main
             git checkout -b hotfix
             touch hotfix
             git add hotfix
@@ -425,7 +425,7 @@ fn test_protected_feature_to_develop() -> Result<()> {
 }
 
 #[test]
-fn test_protected_feature_to_master() -> Result<()> {
+fn test_protected_feature_to_main() -> Result<()> {
     let guard = fixture().prepare(
         "local",
         r#"
@@ -446,7 +446,7 @@ fn test_protected_feature_to_master() -> Result<()> {
             git checkout develop
             git merge refs/pull/1/head
 
-            git checkout master
+            git checkout main
             git merge develop
         EOF
 

--- a/tests/triangular_github_flow.rs
+++ b/tests/triangular_github_flow.rs
@@ -34,7 +34,7 @@ fn fixture() -> Fixture {
             git config push.default simple
             git remote add upstream ../upstream
             git fetch upstream
-            git branch -u upstream/master master
+            git branch -u upstream/main main
         EOF
         # prepare awesome patch
         local <<EOF


### PR DESCRIPTION
Github has been using `main` as the default branch name for a while now.
This change updates the branch name in the codebase and the tests so
they work with the default branch name set to `main`.

To make this change locally, you can run the following commands:

    git config --global init.defaultBranch main

I'd suggest also updating the branch name for this repository to `main`
as well and updating the github workflows.
